### PR TITLE
Freeze sphinx to at most 1.7.3

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx >= 1.6.5, < 2
+sphinx >= 1.6.5, < 1.7.3
 numpydoc


### PR DESCRIPTION
Fix master branch.

- Breaks for sphinx == 1.7.3

I don't know why. :sweat_smile:

Note: This is to allow merging #58, #62 and #63 without waiting for #59 .