### PR TITLE
Add default value support for dimensions

### DIFF
--- a/src/orion/core/io/space_builder.py
+++ b/src/orion/core/io/space_builder.py
@@ -163,6 +163,7 @@ class DimensionBuilder(object, metaclass=SingletonType):
         globals_ = {'__builtins__': {}}
         try:
             dimension = eval("self." + expression, globals_, {'self': self})
+            
             return dimension
         except AttributeError:
             pass
@@ -183,6 +184,7 @@ class DimensionBuilder(object, metaclass=SingletonType):
                             "'{1}' does not correspond to a supported distribution.".format(
                                 name, prior))
         dimension = klass(name, prior, *args, **kwargs)
+
         return dimension
 
     def build(self, name, expression):
@@ -220,8 +222,8 @@ class SpaceBuilder(object, metaclass=SingletonType):
 
     USERCONFIG_OPTION = '--config='
     USERCONFIG_KEYWORD = 'orion~'
-    USERARGS_SEARCH = r'\W*([a-zA-Z0-9_-]+)~(.*)'
-    USERARGS_TMPL = r'(.*)~(.*)'
+    USERARGS_SEARCH = r'\W*([a-zA-Z0-9_-]+)~([a-zA-Z0-9_]+\(.*\))'
+    USERARGS_TMPL = r'(.*)~(.*\(.*\))'
 
     def __init__(self):
         """Initialize a `SpaceBuilder`."""
@@ -313,6 +315,7 @@ class SpaceBuilder(object, metaclass=SingletonType):
 
             name, expression = found[0]
             namespace = '/' + name
+
             dimension = self.dimbuilder.build(namespace, expression)
             self.space.register(dimension)
 


### PR DESCRIPTION
Why: Default values are necessary when inserting a trial manually and
giving only a subset of the space of an experiment as fixed dimensions.
When a dimension is missing, it'll go look inside the configuration and
see if the default value has been set, if not, it'll stop.

How: By adding the default value as a named parameters of the distribution,
the dimension can check if it belongs to its domain and cast it to the correct
type. This limits the actual code impact since the parsing of the parameters
was already done inside the _build function of DimensionBuilder.