### PR TITLE
User can request managerial info, like trial string identifiers, from cli

### DIFF
--- a/src/orion/core/io/space_builder.py
+++ b/src/orion/core/io/space_builder.py
@@ -66,6 +66,20 @@ def _real_or_int(kwargs):
     return Integer if kwargs.pop('discrete', False) else Real
 
 
+def replace_key_in_order(odict, key_prev, key_after):
+    """Replace `key_prev` of `OrderedDict` `odict` with `key_after`,
+    while leaving its value and the rest of the dictionary intact and in the
+    same order.
+    """
+    tmp = collections.OrderedDict()
+    for k, v in odict.items():
+        if k == key_prev:
+            tmp[key_after] = v
+        else:
+            tmp[k] = v
+    return tmp
+
+
 class DimensionBuilder(object, metaclass=SingletonType):
     """Create `Dimension` objects using a name for it and an string expression
     which encodes prior and dimension information.
@@ -220,18 +234,20 @@ class DimensionBuilder(object, metaclass=SingletonType):
 class SpaceBuilder(object, metaclass=SingletonType):
     """Build a `Space` object form user's configuration."""
 
-    USERCONFIG_OPTION = '--config='
+    # TODO Expose these 4 USER oriented goodfellows to a orion configuration file :)
     USERCONFIG_KEYWORD = 'orion~'
-    USERARGS_SEARCH = r'\W*([a-zA-Z0-9_-]+)~(.*)'
     USERARGS_TMPL = r'(.*)~(.*)'
+    USERARGS_NAMESPACE = r'\W*([a-zA-Z0-9_-]+)'
+    USERARGS_CONFIG = '--config='
+
     EXPOSED_PROPERTIES = ['trial.hash_name', 'trial.full_name']
 
     def __init__(self):
         """Initialize a `SpaceBuilder`."""
         self.userconfig = None
-        self.is_userconfig_an_option = None
         self.userargs_tmpl = None
         self.userconfig_tmpl = None
+        self.positional_args_count = 0
 
         self.dimbuilder = DimensionBuilder()
         self.space = None
@@ -269,7 +285,7 @@ class SpaceBuilder(object, metaclass=SingletonType):
         self.commands_tmpl = None
         self.space = Space()
 
-        self.userconfig, self.is_userconfig_an_option = self._build_from_args(cmd_args)
+        self.userconfig = self._build_from_args(cmd_args)
 
         if self.userconfig:
             self._build_from_config(self.userconfig)
@@ -308,56 +324,98 @@ class SpaceBuilder(object, metaclass=SingletonType):
                         raise ValueError(error_msg) from exc
 
     def _build_from_args(self, cmd_args):
+        """Build templates from arguments found in the original cli.
+
+        Rules for namespacing:
+           1. Prefix ``'/'`` is given to parameter dimensions.
+           2. Prefix ``'$'`` is given to substitutions from exposed properties.
+           3. Prefix ``'_'`` is given to arguments which do not interact with.
+              Suffix is a unique integer.
+           4. ``'config'`` is given to user's script configuration file template
+
+        User script configuration file argument is treated specially, trying to
+        recognise a ``--config`` option or by checking the first positional
+        argument, if not found elsewhere. Only one is allowed.
+
+        .. note:: Currently positional arguments cannot define a parameter
+           dimension. And I don't think they will; it wouldn't be good for
+           your health down the line. Please be responsible and give a good
+           descriptive name to your inputs.
+
+        .. note:: Templates preserve given argument order.
+
+        """
         userconfig = None
-        is_userconfig_an_option = None
-        self.userargs_tmpl = collections.defaultdict(list)
-        self.commands_tmpl = dict()
-        args_pattern = re.compile(self.USERARGS_SEARCH)
-        args_prefix_pattern = re.compile(self.USERARGS_TMPL)
+        self.userargs_tmpl = collections.OrderedDict()
+        self.commands_tmpl = collections.OrderedDict()
+        args_pattern = re.compile(self.USERARGS_TMPL)
+        args_namespace_pattern = re.compile(self.USERARGS_NAMESPACE)
+
+        self.positional_args_count = 0
+
+        def get_next_pos_ns():
+            """Generate next namespace for a positional argument."""
+            ns = str(self.positional_args_count)
+            self.positional_args_count += 1
+            return ns
 
         for arg in cmd_args:
             found = args_pattern.findall(arg)
             if len(found) != 1:
-                if arg.startswith(self.USERCONFIG_OPTION):
+                if arg.startswith(self.USERARGS_CONFIG):
                     if not userconfig:
-                        userconfig = arg[len(self.USERCONFIG_OPTION):]
-                        is_userconfig_an_option = True
+                        userconfig = arg[len(self.USERARGS_CONFIG):]
+                        self.userargs_tmpl['config'] = self.USERARGS_CONFIG
                     else:
                         raise ValueError(
                             "Already found one configuration file in: %s" %
                             userconfig
                             )
                 else:
-                    self.userargs_tmpl[None].append(arg)
+                    self.userargs_tmpl['_' + get_next_pos_ns()] = arg
                 continue
 
-            name, expression = found[0]
+            prefix, expression = found[0]
+            ns_search = args_namespace_pattern.findall(prefix)
             if expression in self.EXPOSED_PROPERTIES:
                 # It's a experiment/trial management command
-                namespace = '$' + name
+                namespace = '$'
+                namespace += ns_search[0] if ns_search else get_next_pos_ns()
                 try:
                     objname, attrname = expression.split('.')
                 except ValueError as exc:
                     raise ValueError("Expected dotted expression with two parts "
-                                     "{{object}}.{{attribute}}. "
+                                     "'{{object}}.{{attribute}}'. "
                                      "Got: '{}'".format(expression)) from exc
                 self.commands_tmpl[namespace] = (objname, attrname)
+                self.userargs_tmpl[namespace] = prefix + '=' if ns_search else ''
+            elif not ns_search or not expression or expression[0] == '/':
+                # This branch targets the nameless and the ones that use `~`
+                # as the home directory in a shell path
+                # If it's nameless (positional) it cannot be a dimension
+                log.warning("Nameless argument '%s' will not define a dimension.", arg)
+                self.userargs_tmpl['_' + get_next_pos_ns()] = arg
             else:
-                # Ikr it's a dimension
-                namespace = '/' + name
+                # Otherwise it's a dimension; ikr
+                namespace = '/' + ns_search[0]
                 dimension = self.dimbuilder.build(namespace, expression)
                 self.space.register(dimension)
+                self.userargs_tmpl[namespace] = prefix + '='
 
-            found = args_prefix_pattern.findall(arg)
-            assert len(found) == 1 and found[0][1] == expression, "Parsing prefix problem."
-            self.userargs_tmpl[namespace] = found[0][0] + '='
+        # Risky assumption about the first non-interacting argument being a
+        # user's script configuration file. May be dropped in the future.
+        # Quite surely if TODO @221 is implemented because user can specify
+        # how their configuration is supposed to be parsed, so ciao.
+        # For now issue a warning if this is going to happen.
+        if not userconfig and '_0' in self.userargs_tmpl:
+            if os.path.isfile(self.userargs_tmpl['_0']):
+                userconfig = self.userargs_tmpl['_0']
+                log.warning("Using '%s' as path to user script's configuration file!", userconfig)
+                # '_0' is 'config' now, replace key in the correct order
+                self.userargs_tmpl = replace_key_in_order(self.userargs_tmpl, '_0', 'config')
+                self.userargs_tmpl['config'] = ''
 
-        if not userconfig and self.userargs_tmpl[None]:  # try the first positional argument
-            if os.path.isfile(self.userargs_tmpl[None][0]):
-                userconfig = self.userargs_tmpl[None].pop(0)
-                is_userconfig_an_option = False
-
-        return userconfig, is_userconfig_an_option
+        return userconfig
 
     def build_to(self, config_path, trial):
         """Use templates saved from `build_from` to generate a config file (if needed)
@@ -405,25 +463,19 @@ class SpaceBuilder(object, metaclass=SingletonType):
         cmd_args = []
         # objects whose properties can be fetched to fill a cli argument
         exposed_objects = {'trial': trial}
+        param_names = [trial.params[i].name for i in range(len(trial.params))]
 
-        if self.userconfig:
-            if self.is_userconfig_an_option:
-                cmd_args.append(self.USERCONFIG_OPTION + config_path)
-            else:
-                cmd_args.append(config_path)
-
-        cmd_args.extend(self.userargs_tmpl[None])
-
-        for param in trial.params:
-            if param.name not in self.userargs_tmpl:
-                continue
-            prefix = self.userargs_tmpl[param.name]
-            cmd_args.append(prefix + str(param.value))
-
-        for namespace, (objname, attrname) in self.commands_tmpl.items():
-            obj = exposed_objects[objname]
-            item = getattr(obj, attrname)
-            prefix = self.userargs_tmpl[namespace]
-            cmd_args.append(prefix + item)
+        for namespace, prefix in self.userargs_tmpl.items():
+            if namespace == 'config':
+                cmd_args.append(prefix + config_path)
+            elif namespace.startswith('/'):
+                param_idx = param_names.index(namespace)
+                cmd_args.append(prefix + str(trial.params[param_idx].value))
+            elif namespace.startswith('$'):
+                objname, attrname = self.commands_tmpl[namespace]
+                item = getattr(exposed_objects[objname], attrname)
+                cmd_args.append(prefix + item)
+            elif namespace.startswith('_'):
+                cmd_args.append(prefix)
 
         return cmd_args

--- a/src/orion/core/io/space_builder.py
+++ b/src/orion/core/io/space_builder.py
@@ -337,10 +337,8 @@ class SpaceBuilder(object, metaclass=SingletonType):
         recognise a ``--config`` option or by checking the first positional
         argument, if not found elsewhere. Only one is allowed.
 
-        .. note:: Currently positional arguments cannot define a parameter
-           dimension. And I don't think they will; it wouldn't be good for
-           your health down the line. Please be responsible and give a good
-           descriptive name to your inputs.
+        .. note:: Positional arguments cannot define a parameter
+           dimension, because no **meaningful** name can be assigned.
 
         .. note:: Templates preserve given argument order.
 

--- a/src/orion/core/worker/consumer.py
+++ b/src/orion/core/worker/consumer.py
@@ -91,7 +91,7 @@ class Consumer(object):
         log.debug("## New temp results file: %s", results_file.name)
 
         log.debug("## Building command line argument and configuration for trial.")
-        cmd_args = self.template_builder.build_to(config_file.name, trial)
+        cmd_args = self.template_builder.build_to(config_file.name, trial, self.experiment)
 
         log.debug("## Launch user's script as a subprocess and wait for finish.")
         script_process = self.launch_process(results_file.name, cmd_args)

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -244,7 +244,10 @@ class Trial(object):
 
     @property
     def hash_name(self):
-        """Generate a unique name with an md5sum hash for this `Trial`."""
+        """Generate a unique name with an md5sum hash for this `Trial`.
+
+        .. note:: Two trials that have the same `params` must have the same `hash_name`.
+        """
         if not self.params:
             raise ValueError("Cannot distinguish this trial, as 'params' have not been set.")
         return hashlib.md5(self.params_repr().encode('utf-8')).hexdigest()
@@ -254,7 +257,7 @@ class Trial(object):
         """Generate a unique name using the full definition of parameters."""
         if not self.params:
             raise ValueError("Cannot distinguish this trial, as 'params' have not been set.")
-        return self.params_repr(sep='-')
+        return self.params_repr(sep='-').replace('/', '.')
 
     def _fetch_one_result_of_type(self, result_type):
         value = [result for result in self.results

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -244,10 +244,17 @@ class Trial(object):
 
     @property
     def hash_name(self):
-        """Generate a unique name for this `Trial`."""
+        """Generate a unique name with an md5sum hash for this `Trial`."""
         if not self.params:
             raise ValueError("Cannot distinguish this trial, as 'params' have not been set.")
         return hashlib.md5(self.params_repr().encode('utf-8')).hexdigest()
+
+    @property
+    def full_name(self):
+        """Generate a unique name using the full definition of parameters."""
+        if not self.params:
+            raise ValueError("Cannot distinguish this trial, as 'params' have not been set.")
+        return self.params_repr(sep='-')
 
     def _fetch_one_result_of_type(self, result_type):
         value = [result for result in self.results

--- a/tests/functional/demo/dir_per_trial.py
+++ b/tests/functional/demo/dir_per_trial.py
@@ -9,6 +9,12 @@ import os
 from orion.client import report_results
 
 
+def function(x):
+    """Evaluate partial information of a quadratic."""
+    z = x - 34.56789168765984988448213179176
+    return 4 * z**2 + 23.4, 8 * z
+
+
 def execute():
     """Execute a simple pipeline as an example."""
     parser = argparse.ArgumentParser()
@@ -22,15 +28,18 @@ def execute():
     os.makedirs(os.path.join(inputs.dir, inputs.other_name, "my-exp-{}".format(inputs.name)),
                 exist_ok=False)  # Raise OSError if it exists
 
+    y, dy = function(inputs.x)
+
     results = list()
     results.append(dict(
-        name='from_{}'.format(inputs.name),
+        name='example_objective',
         type='objective',
-        value=66))
+        value=y))
     results.append(dict(
         name='example_gradient',
         type='gradient',
-        value=[1]))
+        value=[dy]))
+
     report_results(results)
 
 

--- a/tests/functional/demo/dir_per_trial.py
+++ b/tests/functional/demo/dir_per_trial.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Simple script simulating behaviour of a program that requires inputs
+to determine and interact with a unique directory in local disk.
+"""
+import argparse
+import os
+
+from orion.client import report_results
+
+
+def execute():
+    """Execute a simple pipeline as an example."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-x', type=float, required=True)
+    parser.add_argument('--dir', type=str, required=True)
+    parser.add_argument('--name', type=str, required=True)
+    inputs = parser.parse_args()
+
+    # That's what is expected to happen
+    os.makedirs(os.path.join(inputs.dir, "my-exp-{}".format(inputs.name)),
+                exist_ok=False)  # Raise OSError if it exists
+
+    results = list()
+    results.append(dict(
+        name='from_{}'.format(inputs.name),
+        type='objective',
+        value=66))
+    results.append(dict(
+        name='example_gradient',
+        type='gradient',
+        value=[1]))
+    report_results(results)
+
+
+if __name__ == "__main__":
+    execute()

--- a/tests/functional/demo/dir_per_trial.py
+++ b/tests/functional/demo/dir_per_trial.py
@@ -15,10 +15,11 @@ def execute():
     parser.add_argument('-x', type=float, required=True)
     parser.add_argument('--dir', type=str, required=True)
     parser.add_argument('--name', type=str, required=True)
+    parser.add_argument('--other-name', type=str, required=True)
     inputs = parser.parse_args()
 
     # That's what is expected to happen
-    os.makedirs(os.path.join(inputs.dir, "my-exp-{}".format(inputs.name)),
+    os.makedirs(os.path.join(inputs.dir, inputs.other_name, "my-exp-{}".format(inputs.name)),
                 exist_ok=False)  # Raise OSError if it exists
 
     results = list()

--- a/tests/functional/demo/stress_gradient.yaml
+++ b/tests/functional/demo/stress_gradient.yaml
@@ -1,12 +1,7 @@
-name: voila_voici
-
-pool_size: 1
-max_trials: 100
-
 algorithms:
   gradient_descent:
-    learning_rate: 0.1
-    # dx_tolerance: 1e-7
+    learning_rate: 0.23
+    dx_tolerance: 0
 
 database:
   type: 'mongodb'

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -195,8 +195,6 @@ def test_stress_unique_folder_creation(database, monkeypatch, tmpdir, capfd):
     """Test integration with a possible framework that needs to create
     unique directories per trial.
     """
-    # XXX: ~trial.full_name has a bug.
-    # returned str cannot contain '/' if it is to be a single dir
     # XXX: return and complete test when there is a way to control random
     # seed of Oríon
     how_many = 1000

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -203,6 +203,7 @@ def test_unique_folder_creation(database, monkeypatch, tmpdir):
                                 "--config", "./orion_config_random.yaml",
                                 "./dir_per_trial.py",
                                 "--dir={}".format(str(tmpdir)),
+                                "--other-name~exp.name",
                                 "--name~trial.hash_name",
                                 "-x~uniform(-50, 50)"])
     rcode = process.wait()
@@ -216,4 +217,5 @@ def test_unique_folder_creation(database, monkeypatch, tmpdir):
 
     trials_c = list(database.trials.find({'experiment': exp_id, 'status': 'completed'}))
     assert len(trials_c) == 3
-    assert len(os.listdir(str(tmpdir))) == 3
+    assert len(os.listdir(str(tmpdir))) == 1
+    assert len(os.listdir(str(tmpdir.join('lalala')))) == 3

--- a/tests/functional/gradient_descent_algo/src/orion/algo/gradient_descent.py
+++ b/tests/functional/gradient_descent_algo/src/orion/algo/gradient_descent.py
@@ -16,9 +16,11 @@ from orion.algo.base import BaseAlgorithm
 class Gradient_Descent(BaseAlgorithm):
     """Implement a gradient descent algorithm."""
 
-    def __init__(self, space, learning_rate=1.):
+    def __init__(self, space, learning_rate=1., dx_tolerance=1e-7):
         """Declare `learning_rate` as a hyperparameter of this algorithm."""
-        super(Gradient_Descent, self).__init__(space, learning_rate=learning_rate)
+        super(Gradient_Descent, self).__init__(space,
+                                               learning_rate=learning_rate,
+                                               dx_tolerance=dx_tolerance)
         self.has_observed_once = False
         self.current_point = None
         self.gradient = numpy.array([numpy.inf])
@@ -50,4 +52,5 @@ class Gradient_Descent(BaseAlgorithm):
     @property
     def is_done(self):
         """Implement a terminating condition."""
-        return self.learning_rate * numpy.sqrt(self.gradient.dot(self.gradient)) <= 1e-7
+        dx = self.learning_rate * numpy.sqrt(self.gradient.dot(self.gradient))
+        return dx <= self.dx_tolerance

--- a/tests/unittests/core/mongodb_test.py
+++ b/tests/unittests/core/mongodb_test.py
@@ -47,7 +47,6 @@ class TestConnection(object):
         with pytest.raises(pymongo.errors.ConnectionFailure) as exc_info:
             MongoDB(host='asdfada', port=123, name='orion',
                     username='uasdfaf', password='paasdfss')
-        assert "Name or service not known" in str(exc_info.value)
 
         monkeypatch.undo()
 

--- a/tests/unittests/core/test_space_builder.py
+++ b/tests/unittests/core/test_space_builder.py
@@ -430,7 +430,7 @@ class TestSpaceBuilder(object):
             "--seed=555",
             "-yolo=-2.4",
             "--arch1=choices({'lala': 0.2, 'yolo': 0.8})",
-            "--arch2=yolo", "--name=/yolo:-2.4-/arch2:yolo"]
+            "--arch2=yolo", "--name=.yolo:-2.4-.arch2:yolo"]
 
     def test_handle_not_exposed_properties(self, spacebuilder):
         """Build arguments using something which is neither legit exposed property,

--- a/tests/unittests/core/test_space_builder.py
+++ b/tests/unittests/core/test_space_builder.py
@@ -224,15 +224,16 @@ class TestSpaceBuilder(object):
                     "--arch2~choices({'lala': 0.2, 'yolo': 0.8})",
                     "~trial.full_name",
                     "--some-path=~/fadlfal",
-                    "--home-path-for-no-reason-whatsoever=~"]
+                    "--home-path-for-no-reason-whatsoever=~",
+                    "~/../dasfa/.giasdf/fadsfdas"]
         space = spacebuilder.build_from(cmd_args)
         print(space)
         assert spacebuilder.userconfig is None
         assert len(space) == 2
         assert '/yolo' in space
         assert '/arch2' in space
-        assert list(spacebuilder.userargs_tmpl.keys()) == ['_0', '/yolo', '_1',
-                                                           '/arch2', '$2', '_3', '_4']
+        assert list(spacebuilder.userargs_tmpl.keys()) == ['_0', '/yolo', '_1', '/arch2',
+                                                           '$2', '_3', '_4', '_5']
         assert spacebuilder.userargs_tmpl['_0'] == "--seed=555"
         assert spacebuilder.userargs_tmpl['/yolo'] == "-yolo="
         assert spacebuilder.userargs_tmpl['_1'] == "--arch1=choices({'lala': 0.2, 'yolo': 0.8})"
@@ -240,6 +241,7 @@ class TestSpaceBuilder(object):
         assert spacebuilder.userargs_tmpl['$2'] == ""
         assert spacebuilder.userargs_tmpl['_3'] == "--some-path=~/fadlfal"
         assert spacebuilder.userargs_tmpl['_4'] == "--home-path-for-no-reason-whatsoever=~"
+        assert spacebuilder.userargs_tmpl['_5'] == "~/../dasfa/.giasdf/fadsfdas"
 
     def test_build_from_args_and_config1(self, spacebuilder, yaml_sample_path):
         """Build a space using both args and config file!"""

--- a/tests/unittests/core/test_space_builder.py
+++ b/tests/unittests/core/test_space_builder.py
@@ -413,7 +413,7 @@ class TestSpaceBuilder(object):
                                'something-same': '3'}
 
     def test_generate_from_args_plus_properties(self, spacebuilder):
-        """Build a space using definitions from cli arguments and a json file."""
+        """Build arguments using definitions from cli arguments and a json file."""
         cmd_args = ["--seed=555",
                     "-yolo~uniform(-3, 1)",
                     "--arch1=choices({'lala': 0.2, 'yolo': 0.8})",
@@ -429,3 +429,11 @@ class TestSpaceBuilder(object):
             "-yolo=-2.4",
             "--arch1=choices({'lala': 0.2, 'yolo': 0.8})",
             "--arch2=yolo", "--name=/yolo:-2.4-/arch2:yolo"]
+
+    def test_handle_not_exposed_properties(self, spacebuilder):
+        """Build arguments using something which is neither legit exposed property,
+        nor legit dimension definition."""
+        cmd_args = ["--name~trial.asdfad"]
+        with pytest.raises(TypeError) as exc:
+            spacebuilder.build_from(cmd_args)
+        assert 'trial.asdfad' in str(exc.value)

--- a/tests/unittests/core/test_space_builder.py
+++ b/tests/unittests/core/test_space_builder.py
@@ -373,7 +373,7 @@ class TestSpaceBuilder(object):
 
     def test_generate_from_args_and_config(self, spacebuilder,
                                            json_sample_path, tmpdir, json_converter):
-        """Build a space using only a json config."""
+        """Build a space using definitions from cli arguments and a json file."""
         cmd_args = ["--seed=555",
                     "-yolo~uniform(-3, 1)",
                     '--config=' + json_sample_path,
@@ -402,3 +402,21 @@ class TestSpaceBuilder(object):
                                           {'width': 100, 'type': 'relu'},
                                           {'width': 16, 'type': 'sigmoid'}],
                                'something-same': '3'}
+
+    def test_generate_from_args_plus_properties(self, spacebuilder):
+        """Build a space using definitions from cli arguments and a json file."""
+        cmd_args = ["--seed=555",
+                    "-yolo~uniform(-3, 1)",
+                    "--arch1=choices({'lala': 0.2, 'yolo': 0.8})",
+                    "--arch2~choices({'lala': 0.2, 'yolo': 0.8})",
+                    "--name~trial.full_name"]
+        spacebuilder.build_from(cmd_args)
+        trial = Trial(params=[
+            {'name': '/yolo', 'type': 'real', 'value': -2.4},
+            {'name': '/arch2', 'type': 'categorical', 'value': 'yolo'}])
+        cmd_inst = spacebuilder.build_to(None, trial)
+        assert cmd_inst == [
+            "--seed=555",
+            "--arch1=choices({'lala': 0.2, 'yolo': 0.8})",
+            "-yolo=-2.4",
+            "--arch2=yolo", "--name=/yolo:-2.4-/arch2:yolo"]

--- a/tests/unittests/core/test_space_builder.py
+++ b/tests/unittests/core/test_space_builder.py
@@ -434,7 +434,8 @@ class TestSpaceBuilder(object):
 
     def test_handle_not_exposed_properties(self, spacebuilder):
         """Build arguments using something which is neither legit exposed property,
-        nor legit dimension definition."""
+        nor legit dimension definition.
+        """
         cmd_args = ["--name~trial.asdfad"]
         with pytest.raises(TypeError) as exc:
             spacebuilder.build_from(cmd_args)

--- a/tests/unittests/core/test_trial.py
+++ b/tests/unittests/core/test_trial.py
@@ -179,7 +179,7 @@ class TestTrial(object):
     def test_full_name_property(self, exp_config):
         """Check property `Trial.full_name`."""
         t = Trial(**exp_config[1][2])
-        assert t.full_name == "/encoding_layer:gru-/decoding_layer:lstm_with_attention"
+        assert t.full_name == ".encoding_layer:gru-.decoding_layer:lstm_with_attention"
 
         t = Trial()
         with pytest.raises(ValueError) as exc:

--- a/tests/unittests/core/test_trial.py
+++ b/tests/unittests/core/test_trial.py
@@ -93,8 +93,11 @@ class TestTrial(object):
     def test_str_trial(self, exp_config):
         """Test representation of `Trial`."""
         t = Trial(**exp_config[1][2])
-        assert str(t) == "Trial(experiment='supernaedo2', "\
-                         "status='completed', params.value=['gru', 'lstm_with_attention'])"
+        assert str(t) == "Trial(experiment='supernaedo2', status='completed',\n"\
+                         "      params=/encoding_layer:gru\n"\
+                         "             /decoding_layer:lstm_with_attention)"
+        print()
+        print(str(t))
 
     def test_str_value(self, exp_config):
         """Test representation of `Trial.Value`."""
@@ -153,3 +156,22 @@ class TestTrial(object):
         assert t.gradient.type == 'gradient'
         assert t.gradient.value == [5, 3]
         tmp = exp_config[1][2]['results'].pop()
+
+    def test_params_repr_property(self, exp_config):
+        """Check property `Trial.params_repr`."""
+        t = Trial(**exp_config[1][2])
+        assert t.params_repr() == "/encoding_layer:gru,/decoding_layer:lstm_with_attention"
+        assert t.params_repr(sep='\n') == "/encoding_layer:gru\n/decoding_layer:lstm_with_attention"
+
+        t = Trial()
+        assert t.params_repr() == ""
+
+    def test_name_property(self, exp_config):
+        """Check property `Trial.name`."""
+        t = Trial(**exp_config[1][2])
+        assert t.hash_name == "29ae84d14c5655000fa7f1b608f16008"
+
+        t = Trial()
+        with pytest.raises(ValueError) as exc:
+            t.hash_name
+        assert 'params' in str(exc.value)

--- a/tests/unittests/core/test_trial.py
+++ b/tests/unittests/core/test_trial.py
@@ -166,12 +166,22 @@ class TestTrial(object):
         t = Trial()
         assert t.params_repr() == ""
 
-    def test_name_property(self, exp_config):
-        """Check property `Trial.name`."""
+    def test_hash_name_property(self, exp_config):
+        """Check property `Trial.hash_name`."""
         t = Trial(**exp_config[1][2])
         assert t.hash_name == "29ae84d14c5655000fa7f1b608f16008"
 
         t = Trial()
         with pytest.raises(ValueError) as exc:
             t.hash_name
+        assert 'params' in str(exc.value)
+
+    def test_full_name_property(self, exp_config):
+        """Check property `Trial.full_name`."""
+        t = Trial(**exp_config[1][2])
+        assert t.full_name == "/encoding_layer:gru-/decoding_layer:lstm_with_attention"
+
+        t = Trial()
+        with pytest.raises(ValueError) as exc:
+            t.full_name
         assert 'params' in str(exc.value)


### PR DESCRIPTION
Why:
   I need to way to identify saved stuff in local disk from the
   execution of my script given a particular trial. This way I can have
   a reproducible deterministic string identifier that I intend to pass
   appropriately to a command line argument (if specified from ``orion
   hunt``) of my executable. This will disambiguate saved states,
   snapshots, or logs (i.e. from tensorboard), among different trials of
   the same executable.

   The actual implementation of all save/load is left to the executable
   itself, as well as configuring the absolute path where the stuff will
   be saved to. Most (responsible) ML programs I have personally encountered
   have a cli way to specify some naming for the experiment to run.