### PR TITLE
Fix: Convert ndarrays to lists because they are not bsonable

### DIFF
--- a/src/orion/algo/space.py
+++ b/src/orion/algo/space.py
@@ -601,3 +601,52 @@ class Space(OrderedDict):
         """Represent as a string the space and the dimensions it contains."""
         dims = list(self.values())
         return "Space([{}])".format(',\n       '.join(map(str, dims)))
+
+
+def pack_point(point, space):
+    """Take a list of points and pack it appropriately as a point from `space`.
+
+    :param point: array-like or list of numbers
+    :param space: problem's parameter definition,
+       instance of `orion.algo.space.Space`
+
+    .. note:: It works only if dimensions included in `space` have 0D or 1D shape.
+
+    :returns: list of numbers or tuples
+    """
+    packed = []
+    idx = 0
+    for dim in space.values():
+        shape = dim.shape
+        if shape:
+            assert len(shape) == 1
+            next_idx = idx + shape[0]
+            packed.append(tuple(point[idx:next_idx]))
+            idx = next_idx
+        else:
+            packed.append(point[idx])
+            idx += 1
+    assert packed in space
+    return packed
+
+
+def unpack_point(point, space):
+    """Flatten `point` in `space` and convert it to a 1D `numpy.ndarray`.
+
+    :param point: list of number or tuples, in `space`
+    :param space: problem's parameter definition,
+       instance of `orion.algo.space.Space`
+
+    .. note:: It works only if dimensions included in `space` have 0D or 1D shape.
+
+    :returns: a list of float numbers
+    """
+    unpacked = []
+    for subpoint, dim in zip(point, space.values()):
+        shape = dim.shape
+        if shape:
+            assert len(shape) == 1
+            unpacked.extend(subpoint)
+        else:
+            unpacked.append(subpoint)
+    return unpacked

--- a/src/orion/core/utils/format_trials.py
+++ b/src/orion/core/utils/format_trials.py
@@ -34,11 +34,17 @@ def tuple_to_trial(data, space):
     :type space: `orion.algo.space.Space`
     """
     assert len(data) == len(space)
-    params = [dict(
-        name=space[order].name,
-        type=space[order].type,
-        value=data[order]
-        ) for order in range(len(space))]
+    params = []
+    for i, dim in enumerate(space.values()):
+        try:
+            datum = data[i].tolist()  # if it is numpy.ndarray
+        except AttributeError:
+            datum = data[i]
+        params.append(dict(
+            name=dim.name,
+            type=dim.type,
+            value=datum
+            ))
     return Trial(params=params)
 
 


### PR DESCRIPTION
**Case**:
Use random optimization for a single (3,)-shaped dimension.

**Reproduce**:
In bouthilx/orion.algo.skopt#3 run:
```
export ORION_DB_NAME=orion_test
export ORION_DB_ADDRESS=mongodb://user:pass@localhost
orion -n=test --pool-size=1 --max-trials=10 ./tests/rosenbrock.py -x~'uniform(-5, 5, shape=3)'
```

**Traceback**:
from ``worker.__init__.py``:line 42 (workon)
``producer.produce()``
from ``worker.experiment.py``:line 228 (register_trials)
``self._db.write('trials', trials_dicts)``
from ``mongodb.py``:line 41 (write)
``result = dbcollection.insert_many(documents=data)``

**Raises**:
``bson.errors.InvalidDocument: Cannot encode object: array([0.8, 1.3])``