### PR TITLE
Add adapters for experiment version control

### DIFF
--- a/src/orion/core/evc/__init__.py
+++ b/src/orion/core/evc/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.evc` -- Experiment Version Control System
+==========================================================
+
+.. module:: evc
+   :platform: Unix
+   :synopsis: Organize related experiments inside a tree-structure using adapters to maintain
+      compatibility between them.
+"""

--- a/src/orion/core/evc/adapters.py
+++ b/src/orion/core/evc/adapters.py
@@ -1,0 +1,694 @@
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.evc.adapters` -- Adapters to connect experiments within the EVC system
+=======================================================================================
+
+.. module:: adapters
+   :platform: Unix
+   :synopsis: Adapters to connect experiments within the EVC system
+
+Experiment branches because of changes in the configuration or the user's code. This make
+experiments incompatible with one another unless we define adapters such that a branched experiment
+B can access trials from parent experiment A.
+
+Adapters have two main methods, forward and backward. The method forward defines how trials from
+parent experiment A are filtered or adapted to be compatible with experiment B. Modifications are
+only applied at execution time and are not saved anywhere in the database. Adapters only provides a
+view on an experiment.
+
+There is adapters for
+
+    * Dimension addition
+    * Dimension deletion
+    * Dimension renaming
+    * Change of dimension prior
+    * Change of algorithm
+    * Change of code
+    * Combining different adapters
+
+Adapters all have a `to_dict` method which provides sufficient information to rebuild the adapter.
+This is to facilitate save of adapters in a database and retrieval.
+
+Adapters can be build using the factory class `Adapter(**kwargs)` or using
+`Adapter.build(list_of_dicts)`.
+
+"""
+from abc import (ABCMeta, abstractmethod)
+import copy
+
+from orion.core.io.space_builder import DimensionBuilder
+from orion.core.utils import Factory
+from orion.core.worker.trial import Trial
+
+
+class BaseAdapter(object, metaclass=ABCMeta):
+    """Base class describing what an adapter can do."""
+
+    @abstractmethod
+    def forward(self, trials):
+        """Adapt trials of the parent experiment such that they are compatible to the child
+        experiment
+
+        Parameters
+        ----------
+        trials: list of :class:`orion.core.worker.trial.Trial`
+            List of :class:`orion.core.worker.trial.Trial` coming from the parent experiment
+
+        """
+        pass
+
+    @abstractmethod
+    def backward(self, trials):
+        """Adapt trials of the child experiment such that they are compatible to the parent
+        experiment
+
+        Parameters
+        ----------
+        trials: list of :class:`orion.core.worker.trial.Trial`
+            List of :class:`orion.core.worker.trial.Trial` coming from the child experiment
+
+        """
+        pass
+
+    @abstractmethod
+    def to_dict(self):
+        """Provide the configuration of the adapter as a dictionary
+
+        This method is intended for single adapters only.
+        For coherence, method configuration is used by all adapters, which is a list of dictionary
+        configurations.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.adapters.BaseAdapter.configuration`
+        """
+        pass
+
+    @property
+    def configuration(self):
+        """Provide the configuration of the adapter.
+
+        For simplicity, the configuration is always returned as if the adapter is a
+        CompositeAdapter, therefore no matter if the adapter is composite or not it will return a
+        list of configurations.
+
+        The dictionaries of the list can be used to recreate adapters, for any adapter class.
+
+        Examples
+        --------
+        .. code-block:: python
+           :linenos:
+
+            configuration = a_dummy_adapter.configuration[0]
+            another_dummy_adapter = Adapter.build([configuration])
+            assert another_dummy_adapter.configuration[0] == configuration
+
+        Returns
+        -------
+        dict
+            Configuration as a dictionary
+
+        """
+        return [self.to_dict()]
+
+
+class CompositeAdapter(BaseAdapter):
+    """Adapter which group many other adapters needed to connect two experiments
+
+    Attributes
+    ----------
+    adapters: instances of `orion.core.evc.adapters.BaseAdapter`
+        List of adaptors which are applied sequentially
+
+    """
+
+    def __init__(self, *adapters):
+        """Initialize with adapters
+
+        Parameters
+        ----------
+        adapters: instances of `orion.core.evc.adapters.BaseAdapter`
+            List of adaptors which are applied sequentially
+
+        """
+        if any(not isinstance(adapter, BaseAdapter) for adapter in adapters):
+            wrong_object_type = [type(adapter) for adapter in adapters
+                                 if not isinstance(adapter, BaseAdapter)][0]
+            raise TypeError("Provided adapters must be adapter objects, not '%s'" %
+                            str(wrong_object_type))
+
+        self.adapters = adapters
+
+    def forward(self, trials):
+        """Apply the adaptors on the parent's trials
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        for adapter in self.adapters:
+            trials = adapter.forward(trials)
+
+        return trials
+
+    def backward(self, trials):
+        """Apply the adaptors backward and in reverse order on the parent's trials
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.backward`
+        """
+        for adapter in self.adapters[::-1]:
+            trials = adapter.backward(trials)
+
+        return trials
+
+    def to_dict(self):
+        """Return nothing since it is not valid for CompositeAdapter
+
+        .. seealso::
+
+            :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
+            :meth:`orion.core.evc.adapters.CompositeAdapter.configuration`
+        """
+        pass
+
+    @property
+    def configuration(self):
+        """Provide the configuration of the adapter.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.configuration`
+        """
+        return [adapter.to_dict() for adapter in self.adapters]
+
+
+def apply_if_valid(name, trial, callback=None, raise_if_not=True):
+    """Detect a parameter in trial and call a callback on it if provided
+
+    Parameters
+    ----------
+    name: str
+        Name of the param to look for
+    trial: `orion.core.worker.trial.Trial`
+        Instance of trial to investigate
+    callback: None of callable
+        Function to call with (trial, param) with a parameter is found.
+        Defaults to None
+    raise_if_not: bool
+        raises RuntimeError if no parameter is found.
+        Defaults to True.
+
+    Returns
+    -------
+    bool
+        False if parameter is not found and `raise_if_not is False`.
+        True if parameter is found and callback is None.
+        Else, output of callback(trial, item).
+
+    """
+    for param in trial.params:
+        if param.name == name:
+            return callback is None or callback(trial, param)
+
+    if raise_if_not:
+        raise RuntimeError("Provided trial does not have a compatible configuration. "
+                           "A dimension named '%s' should be present.\n %s" %
+                           (name, trial))
+
+    return False
+
+
+class DimensionAddition(BaseAdapter):
+    """Adapter which adds a new dimension to parent's trials
+
+    This adaptation is based on the assumption that the trials of the parent experiment
+    are equivalent if we add the new dimension for a given default value.
+
+    On forward, the adapter add a dimension with provided default value to each trials.
+    On backward, the adapter filters trials and only keep with with the default value.
+
+    Attributes
+    ----------
+    param: instances of `orion.core.worker.trial.Trial.Param`
+        A parameter object which defines the name and default value of the name dimension.
+
+    """
+
+    def __init__(self, param):
+        """Initialize and instantiate the param if necessary
+
+        Parameters
+        ----------
+        param: instance of `orion.core.worker.trial.Trial.Param` or `dict`
+            A parameter object which defines the name and default value of the name dimension.
+            It can be either a dictionary definition or an instance of Param. If the former, then
+            a parameter is instantiated from the dictionary.
+
+        """
+        if isinstance(param, dict):
+            param = Trial.Param(**param)
+        elif not isinstance(param, Trial.Param):
+            raise TypeError("Invalid param argument type ('%s'). "
+                            "Param argument must be a Param object or a dictionnary "
+                            "as defined by Trial.Param.to_dict()." %
+                            str(type(param)))
+
+        self.param = param
+
+    def forward(self, trials):
+        """Add a dimension with provided default value to each trials of the parent
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        adapted_trials = []
+
+        for trial in trials:
+            if apply_if_valid(self.param.name, trial, raise_if_not=False):
+                raise RuntimeError("Provided trial does not have a compatible configuration. "
+                                   "A dimension named '%s' was already present.\n %s" %
+                                   (self.param.name, trial))
+
+            adapted_trial = copy.deepcopy(trial)
+            adapted_trial.params.append(self.param)
+            adapted_trials.append(adapted_trial)
+
+        return adapted_trials
+
+    def backward(self, trials):
+        """Filter out trials which have values different than the default one.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.backward`
+        """
+        adapted_trials = []
+
+        def remove_dimension(trial, param):
+            """Remove the param and keep the trial if param has default value"""
+            if param == self.param:
+                adapted_trial = copy.deepcopy(trial)
+                del adapted_trial.params[adapted_trial.params.index(self.param)]
+                adapted_trials.append(adapted_trial)
+                return True
+
+            return False
+
+        for trial in trials:
+            apply_if_valid(self.param.name, trial, remove_dimension, raise_if_not=True)
+
+        return adapted_trials
+
+    def to_dict(self):
+        """Provide the configuration of the adapter as a dictionary
+
+        .. seealso::
+
+            :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
+        """
+        ret = dict(
+            of_type=self.__class__.__name__.lower(),
+            param=self.param.to_dict())
+        return ret
+
+
+class DimensionDeletion(BaseAdapter):
+    """Adapter which remove a dimension to parent's trials
+
+    .. note::
+
+        This adapter is the opposite of `orion.core.evc.adapters.DimensionAddition`.
+
+    This adaptation is based on the assumption that the trials of the children experiment
+    are equivalent if we remove the new dimension for a given default value.
+
+    On forward, the adapter filters trials and only keep with with the default value.
+    On backward, the adapter add a dimension with provided default value to each trials.
+
+    Attributes
+    ----------
+    dimension_addition_adapter: instance of `orion.core.evc.adapters.DimensionAddition`
+        An adapter to add a new dimension, it is used by DimensionDeletion inversely to remove
+        a dimension.
+
+    """
+
+    def __init__(self, param):
+        """Initialize and instantiate the param if necessary
+
+        Parameters
+        ----------
+        param: instance of `orion.core.worker.trial.Trial.Param` or `dict`
+            A parameter object which defines the name and default value of the name dimension.
+            It can be either a dictionary definition or an instance of Param. If the former, then
+            a parameter is instantiated from the dictionary.
+
+        """
+        self.dimension_addition_adapter = DimensionAddition(param)
+
+    @property
+    def param(self):
+        """Parameter containing name and default value"""
+        return self.dimension_addition_adapter.param
+
+    def forward(self, trials):
+        """Filter out trials which have values different than the default one.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.DimensionAddition.backward`
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        return self.dimension_addition_adapter.backward(trials)
+
+    def backward(self, trials):
+        """Add a dimension with provided default value to each trials of the child.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.DimensionAddition.forward`
+            :meth:`orion.core.evc.BaseAdapter.backward`
+        """
+        return self.dimension_addition_adapter.forward(trials)
+
+    def to_dict(self):
+        """Provide the configuration of the adapter as a dictionary
+
+        .. seealso::
+
+            :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
+        """
+        ret = self.dimension_addition_adapter.to_dict()
+        ret['of_type'] = 'dimensiondeletion'
+        return ret
+
+
+class DimensionPriorChange(BaseAdapter):
+    """Adapter which filters parent's trials based on a new prior
+
+    On forward, the adapter filters out trials based on the child's prior.
+    On backward, the adapter filters out trials based on the parent's prior.
+
+    Attributes
+    ----------
+    name: `str`
+        Name of the dimension.
+    old_prior: `str`
+        string definition as parsable by `orion.core.io.space_builder`.
+    new_prior: `str`
+        string definition as parsable by `orion.core.io.space_builder`.
+    old_dimension: instance of `orion.algo.space.Dimension`
+        The dimension of the parent experiment
+    new_dimension: instance of `orion.algo.space.Dimension`
+        The dimension of the child experiment
+
+    """
+
+    def __init__(self, name, old_prior, new_prior):
+        """Initialize and instantiate dimensions
+
+        Parameters
+        ----------
+        name: `str`
+            Name of the dimension.
+        old_prior: `str`
+            string definition as parsable by `orion.core.io.space_builder`.
+        new_prior: `str`
+            string definition as parsable by `orion.core.io.space_builder`.
+
+        """
+        self.name = name
+        self.old_prior = old_prior
+        self.new_prior = new_prior
+        self.old_dimension = DimensionBuilder().build('old', old_prior)
+        self.new_dimension = DimensionBuilder().build('new', new_prior)
+
+        if self.old_dimension.shape != self.new_dimension.shape:
+            raise NotImplementedError("Oríon does not support yet adaptations on prior "
+                                      "shape changes.")
+
+    def forward(self, trials):
+        """Filter out trials which have out of bound values based on the child's prior.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        # pylint: disable=unused-argument
+        def is_in_bound(trial, param):
+            """Test if param's value is in the new prior's bounds"""
+            return param.value in self.new_dimension
+
+        return [trial for trial in trials if apply_if_valid(self.name, trial, callback=is_in_bound)]
+
+    def backward(self, trials):
+        """Filter out trials which have out of bound values based on the parent's prior.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.backward`
+        """
+        return DimensionPriorChange(self.name, self.new_prior, self.old_prior).forward(trials)
+
+    def to_dict(self):
+        """Provide the configuration of the adapter as a dictionary
+
+        .. seealso::
+
+            :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
+        """
+        ret = dict(
+            of_type=self.__class__.__name__.lower(),
+            name=self.name,
+            old_prior=self.old_prior,
+            new_prior=self.new_prior)
+        return ret
+
+
+class DimensionRenaming(BaseAdapter):
+    """Adapter which change the name of a dimension in parent's trials
+
+    On forward, the adapter change dimensions name from A to B.
+    On backward, the adapter change dimensions name from B to A.
+
+    Attributes
+    ----------
+    old_name: `str`
+        Name of the parent's dimension.
+    new_name: `str`
+        Name of the child's dimension.
+
+    """
+
+    def __init__(self, old_name, new_name):
+        """Initialize
+
+        Parameters
+        ----------
+        old_name: `str`
+            Name of the parent's dimension.
+        new_name: `str`
+            Name of the child's dimension.
+
+        """
+        if any(not isinstance(name, str) for name in [old_name, new_name]):
+            wrong_object_type = [type(name) for name in [old_name, new_name]
+                                 if not isinstance(name, str)][0]
+            raise TypeError("Invalid name type '%s'. Names must be strings." %
+                            str(wrong_object_type))
+        self.old_name = old_name
+        self.new_name = new_name
+
+    def forward(self, trials):
+        """Change name of dimension `old_name` to `new_name`.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        # pylint: disable=unused-argument
+        def rename(trial, param):
+            """Rename param to given new name"""
+            param.name = self.new_name
+            return True
+
+        adapted_trials = copy.deepcopy(trials)
+
+        for trial in adapted_trials:
+            apply_if_valid(self.old_name, trial, callback=rename, raise_if_not=True)
+
+        return adapted_trials
+
+    def backward(self, trials):
+        """Change name of dimension `new_name` to `old_name`.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        return DimensionRenaming(self.new_name, self.old_name).forward(trials)
+
+    def to_dict(self):
+        """Provide the configuration of the adapter as a dictionary
+
+        .. seealso::
+
+            :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
+        """
+        ret = dict(
+            of_type=self.__class__.__name__.lower(),
+            old_name=self.old_name,
+            new_name=self.new_name)
+        return ret
+
+
+class AlgorithmChange(BaseAdapter):
+    """Adapter for changes in algorithm definition
+
+    .. note::
+
+        Current implementation does nothing
+
+    """
+
+    def forward(self, trials):
+        """Pass all trials from parent experiment to child experiment
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        return trials
+
+    def backward(self, trials):
+        """Pass all trials from child experiment to parent experiment
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        return trials
+
+    def to_dict(self):
+        """Provide the configuration of the adapter as a dictionary
+
+        .. seealso::
+
+            :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
+        """
+        ret = dict(
+            of_type=self.__class__.__name__.lower())
+        return ret
+
+
+class CodeChange(BaseAdapter):
+    """Adapter which filters parent's trials based on the type of code change
+
+    This adapter let pass all trials if the code change didn't break the compatibility with parent's
+    experiment. If the effect of the change is UNSURE, the trials may only pass from parent to child
+    but not from child to parent. This is to ensure parent experiment does not get corrupted with
+    possibly incompatible results.
+
+    On forward, the adapter filters out parent's trials if type of code change is BREAK.
+    On backward, the adapter filters out child's trials if type of code change is UNSURE or BREAK.
+
+    Attributes
+    ----------
+    change_type: `str`
+        Type of change of the code. Can be one of `CodeChange.NOEFFET`, `CodeChange.BREAK` or
+        `CodeChange.UNSURE`.
+
+    """
+
+    NOEFFECT = "noeffect"
+    BREAK = "break"
+    UNSURE = "unsure"
+    types = [NOEFFECT, BREAK, UNSURE]
+
+    def __init__(self, change_type):
+        """Initialize and check change type's validity
+
+        Parameters
+        ----------
+        change_type: `str`
+            Type of change of the code. Can be one of `CodeChange.NOEFFET`, `CodeChange.BREAK` or
+            `CodeChange.UNSURE`.
+
+        """
+        if change_type not in self.types:
+            raise ValueError("Invalid code change type '%s'. Should be one of %s" %
+                             (change_type, str(self.types)))
+
+        self.change_type = change_type
+
+    def forward(self, trials):
+        """Filter out parent's trials if type of code change is BREAK.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        if self.change_type == self.BREAK:
+            return []
+
+        return trials
+
+    def backward(self, trials):
+        """Filter out child's trials if type of code change is UNSURE or BREAK.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.backward`
+        """
+        if self.change_type in [self.BREAK, self.UNSURE]:
+            return []
+
+        return trials
+
+    def to_dict(self):
+        """Provide the configuration of the adapter as a dictionary
+
+        .. seealso::
+
+            :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
+        """
+        ret = dict(
+            of_type=self.__class__.__name__.lower(),
+            change_type=self.change_type)
+        return ret
+
+
+# pylint: disable=too-few-public-methods,abstract-method
+class Adapter(BaseAdapter, metaclass=Factory):
+    """Class used to inject dependency on an adapter implementation.
+
+    .. seealso:: `orion.core.utils.Factory` metaclass and `BaseAlgorithm` interface.
+    """
+
+    @classmethod
+    def build(cls, adapter_dicts):
+        """Builder method for a list of adapters.
+
+        Parameters
+        ----------
+        adapter_dicts: list of `dict`
+            List of adapter representation in dictionary form as expected to be saved in a database.
+
+        Returns
+        -------
+        `orion.core.evc.adapters.CompositeAdapter`
+            An adapter which may contain many adapters
+
+        """
+        adapters = []
+        for adapter_dict in adapter_dicts:
+            if isinstance(adapter_dict, (list, tuple)):
+                adapter = Adapter.build(adapter_dict)
+            else:
+                adapter = cls(**adapter_dict)
+            adapters.append(adapter)
+
+        return CompositeAdapter(*adapters)

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -132,6 +132,7 @@ class Trial(object):
         function or of an 'constraint' expression.
         """
 
+        __slots__ = ()
         allowed_types = ('objective', 'constraint', 'gradient')
 
     class Param(Value):
@@ -139,6 +140,7 @@ class Trial(object):
         floating precision numerical or a categorical expression (e.g. a string).
         """
 
+        __slots__ = ()
         allowed_types = ('integer', 'real', 'categorical')
 
     __slots__ = ('experiment', '_id', '_status', 'worker',

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -106,6 +106,10 @@ class Trial(object):
                 )
             return ret
 
+        def __eq__(self, other):
+            """Test equality based on self.to_dict()"""
+            return self.name == other.name and self.type == other.type and self.value == other.value
+
         def __str__(self):
             """Represent partially with a string."""
             ret = "{0}(name={1}, type={2}, value={3})".format(

--- a/tests/unittests/core/evc/test_adapters.py
+++ b/tests/unittests/core/evc/test_adapters.py
@@ -1,0 +1,806 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Collection of tests for :mod:`orion.core.evc.adapters`."""
+
+import pytest
+
+from orion.algo.space import Real
+from orion.core.evc.adapters import (
+    Adapter, AlgorithmChange, CodeChange, CompositeAdapter, DimensionAddition, DimensionDeletion,
+    DimensionPriorChange, DimensionRenaming)
+from orion.core.io.space_builder import DimensionBuilder
+from orion.core.worker.trial import Trial
+
+
+@pytest.fixture
+def dummy_param():
+    """Give dummy param integer param with value 1"""
+    return Trial.Param(name='dummy', type='integer', value=1)
+
+
+@pytest.fixture
+def small_prior():
+    """Give string format of small uniform distribution prior"""
+    return "uniform(0, 10)"
+
+
+@pytest.fixture
+def large_prior():
+    """Give string format of large uniform distribution prior"""
+    return "uniform(0, 1000)"
+
+
+@pytest.fixture
+def normal_prior():
+    """Give string format of normal distribution prior"""
+    return "normal(0, 1)"
+
+
+@pytest.fixture
+def disjoint_prior():
+    """Give string format of uniform distribution disjoint from small and large one"""
+    return "uniform(-20, -10)"
+
+
+@pytest.fixture
+def integer_prior():
+    """Give string format of uniform distribution casted to integers"""
+    return "uniform(-20, -10, discrete=True)"
+
+
+@pytest.fixture
+def categorical_prior():
+    """Give string format of categorical prior with floats, integers and strings"""
+    return "choices([0.1, 1, 2, 'string'])"
+
+
+@pytest.fixture
+def multidim_prior():
+    """Give string format of real distribution with multiple dimensions"""
+    return "uniform(0, 10, shape=(2, 2))"
+
+
+@pytest.fixture
+def trials(small_prior, large_prior, normal_prior, disjoint_prior,
+           integer_prior, categorical_prior, multidim_prior):
+    """Trials with dimensions for all priors defined as fixtures"""
+    N_TRIALS = 10
+
+    priors = dict((name, prior) for (name, prior) in locals().items()
+                  if isinstance(name, str) and name.endswith("_prior"))
+
+    trials = []
+    for _ in range(N_TRIALS):
+        params = []
+        for name, prior in priors.items():
+            dimension = DimensionBuilder().build(name, prior)
+            value = dimension.sample()[0]
+            params.append(Trial.Param(name=name, type=dimension.type, value=value).to_dict())
+        trials.append(Trial(params=params))
+
+    return trials
+
+
+class TestDimensionAdditionInit(object):
+    """Test initialization of :class:`orion.core.evc.adapters.DimensionAddition`"""
+
+    def test_dimension_addition_init_with_param(self, dummy_param):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionAddition`
+        with valid param
+        """
+        dimension_addition_adapter = DimensionAddition(dummy_param)
+
+        assert dimension_addition_adapter.param is dummy_param
+
+    def test_dimension_addition_init_with_bad_param(self):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionAddition`
+        with object which is not a param or a dictionary definition of it
+        """
+        with pytest.raises(TypeError) as exc_info:
+            DimensionAddition('bad')
+
+        assert "Invalid param argument type ('<class 'str'>')." in str(exc_info.value)
+
+    def test_dimension_addition_init_with_dict(self, dummy_param):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionAddition`
+        with a dictionary definition of a param
+        """
+        DimensionAddition(dummy_param.to_dict())
+
+    def test_dimension_addition_init_with_bad_dict(self):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionAddition`
+        with a dictionary which is a bad definition of a param
+        """
+        with pytest.raises(AttributeError) as exc_info:
+            DimensionAddition({'bad': 'dict'})
+
+        assert "'Param' object has no attribute 'bad'" in str(exc_info.value)
+
+
+class TestDimensionDeletionInit(object):
+    """Test initialization of :class:`orion.core.evc.adapters.DimensionDeletion`"""
+
+    def test_dimension_deletion_init_with_param(self, dummy_param):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionDeletion`
+        with valid param
+        """
+        dimension_deletion_adapter = DimensionDeletion(dummy_param)
+
+        assert dimension_deletion_adapter.param is dummy_param
+
+    def test_dimension_deletion_init_with_bad_param(self):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionDeletion`
+        with object which is not a param or a dictionary definition of it
+        """
+        with pytest.raises(TypeError) as exc_info:
+            DimensionDeletion('bad')
+
+        assert "Invalid param argument type ('<class 'str'>')." in str(exc_info.value)
+
+    def test_dimension_deletion_init_with_dict(self, dummy_param):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionDeletion`
+        with a dictionary definition of a param
+        """
+        DimensionDeletion(dummy_param.to_dict())
+
+    def test_dimension_deletion_init_with_bad_dict(self):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionDeletion`
+        with a dictionary which is a bad definition of a param
+        """
+        with pytest.raises(AttributeError) as exc_info:
+            print(DimensionDeletion({'bad': 'dict'}).param)
+
+        assert "'Param' object has no attribute 'bad'" in str(exc_info.value)
+
+
+class TestDimensionPriorChangeInit(object):
+    """Test initialization of :class:`orion.core.evc.adapters.DimensionPriorChange`"""
+
+    def test_dimension_prior_change_init_with_dimensions(self, large_prior, small_prior):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionPriorChange`
+        with valid string definitions of dimension prior
+        """
+        dimension_prior_change = DimensionPriorChange('dummy', large_prior, small_prior)
+
+        assert dimension_prior_change.old_prior == large_prior
+        assert dimension_prior_change.new_prior == small_prior
+        assert isinstance(dimension_prior_change.old_dimension, Real)
+        assert isinstance(dimension_prior_change.new_dimension, Real)
+
+        assert dimension_prior_change.old_dimension.interval() == (0, 1000)
+        assert dimension_prior_change.new_dimension.interval() == (0, 10)
+
+    def test_dimension_prior_change_init_with_bad_dimensions(self):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionPriorChange`
+        with non valid string definitions of dimension prior
+        """
+        with pytest.raises(TypeError) as exc_info:
+            DimensionPriorChange('dummy', 'bad', 'priors')
+
+        assert "Parameter 'old': Please provide a valid form for prior" in str(exc_info.value)
+
+
+class TestDimensionRenamingInit(object):
+    """Test initialization of :class:`orion.core.evc.adapters.DimensionRenaming`"""
+
+    def test_dimension_renaming_init(self):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionRenaming`
+        with valid names
+        """
+        dimension_renaming = DimensionRenaming('old_name', 'new_name')
+        assert dimension_renaming.old_name == 'old_name'
+        assert dimension_renaming.new_name == 'new_name'
+
+    def test_dimension_renaming_init_bad_name(self):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionRenaming`
+        with invalid names which are not strings
+        """
+        with pytest.raises(TypeError) as exc_info:
+            DimensionRenaming({'bad': 'name'}, None)
+
+        assert "" in str(exc_info.value)
+
+
+class TestAlgorithmChangeInit(object):
+    """Test initialization of :class:`orion.core.evc.adapters.AlgorithmChange`"""
+
+    def test_algorithm_change_init(self):
+        """Test initialization of :class:`orion.core.evc.adapters.AlgorithmChange`"""
+        AlgorithmChange()
+
+
+class TestCodeChangeInit(object):
+    """Test initialization of :class:`orion.core.evc.adapters.CodeChange`"""
+
+    def test_code_change_init(self):
+        """Test initialization of :class:`orion.core.evc.adapters.CodeChange`
+        with valid change types
+        """
+        code_change_adapter = CodeChange(CodeChange.NOEFFECT)
+        assert code_change_adapter.change_type == CodeChange.NOEFFECT
+
+        code_change_adapter = CodeChange(CodeChange.BREAK)
+        assert code_change_adapter.change_type == CodeChange.BREAK
+
+    def test_code_change_init_bad_type(self):
+        """Test initialization of :class:`orion.core.evc.adapters.CodeChange`
+        with invalid change types
+        """
+        with pytest.raises(ValueError) as exc_info:
+            CodeChange('bad type')
+
+        assert "Invalid code change type 'bad type'" in str(exc_info.value)
+
+
+class TestCompositeAdapterInit(object):
+    """Test initialization of :class:`orion.core.evc.adapters.CompositeAdapter`"""
+
+    def test_composite_adapter_init_emtpy(self):
+        """Test initialization of :class:`orion.core.evc.adapters.CompositeAdapter`
+        with no adapters
+        """
+        composite_adapter = CompositeAdapter()
+        assert len(composite_adapter.adapters) == 0
+
+    def test_composite_adapter_init_with_adapters(self, dummy_param):
+        """Test initialization of :class:`orion.core.evc.adapters.CompositeAdapter`
+        with valid adapters
+        """
+        dimension_addition = DimensionAddition(dummy_param)
+        dimension_deletion = DimensionDeletion(dummy_param)
+        composite_adapter = CompositeAdapter(dimension_addition, dimension_deletion)
+        assert len(composite_adapter.adapters) == 2
+        assert isinstance(composite_adapter.adapters[0], DimensionAddition)
+        assert isinstance(composite_adapter.adapters[1], DimensionDeletion)
+
+    def test_composite_adapter_init_with_bad_adapters(self):
+        """Test initialization of :class:`orion.core.evc.adapters.CompositeAdapter`
+        with invalid adapters
+        """
+        with pytest.raises(TypeError) as exc_info:
+            CompositeAdapter('bad', 'adapters')
+
+        assert ("Provided adapters must be adapter objects, not '<class 'str'>" in
+                str(exc_info.value))
+
+
+def test_adapter_creation(dummy_param):
+    """Test initialization using :meth:`orion.core.evc.adapters.Adapter.build`"""
+    adapter = Adapter.build([{
+        'of_type': 'DimensionAddition',
+        'param': dummy_param.to_dict()}])
+
+    assert isinstance(adapter, CompositeAdapter)
+    assert len(adapter.adapters) == 1
+    assert isinstance(adapter.adapters[0], DimensionAddition)
+    assert adapter.adapters[0].param.to_dict() == dummy_param.to_dict()
+
+
+class TestDimensionAdditionForwardBackward(object):
+    """Test :meth:`orion.core.evc.adapters.DimensionAddition.forward` and
+    :meth:`orion.core.evc.adapters.DimensionAddition.backward`
+    """
+
+    def test_dimension_addition_forward(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionAddition.forward`
+        with valid param and trials
+        """
+        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        dimension_addition_adapter = DimensionAddition(new_param)
+
+        adapted_trials = dimension_addition_adapter.forward(trials)
+
+        assert adapted_trials[0].params[-1] == new_param
+        assert adapted_trials[4].params[-1] == new_param
+        assert adapted_trials[-1].params[-1] == new_param
+
+    def test_dimension_addition_forward_already_existing(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionAddition.forward`
+        with valid param and incompatible trials because param already exists
+        """
+        new_param = Trial.Param(name='normal_prior', type='integer', value=1)
+        dimension_addition_adapter = DimensionAddition(new_param)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            dimension_addition_adapter.forward(trials)
+        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+
+    def test_dimension_addition_backward(self, dummy_param, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionAddition.backward`
+        with valid param and valid trials
+        """
+        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        dimension_addition_adapter = DimensionAddition(new_param)
+
+        sampler = DimensionBuilder().build('random', 'uniform(10, 100, discrete=True)')
+        for trial in trials:
+            random_param = new_param.to_dict()
+            random_param['value'] = sampler.sample()
+            trial.params.append(Trial.Param(**random_param))
+
+        adapted_trials = dimension_addition_adapter.backward(trials)
+        assert len(adapted_trials) == 0
+
+        trials[0].params[-1].value = 1
+        assert trials[0].params[-1] == new_param
+
+        adapted_trials = dimension_addition_adapter.backward(trials)
+        assert len(adapted_trials) == 1
+
+        trials[4].params[-1].value = 1
+        assert trials[4].params[-1] == new_param
+
+        adapted_trials = dimension_addition_adapter.backward(trials)
+        assert len(adapted_trials) == 2
+
+        trials[-1].params[-1].value = 1
+        assert trials[-1].params[-1] == new_param
+
+        adapted_trials = dimension_addition_adapter.backward(trials)
+        assert len(adapted_trials) == 3
+
+        assert new_param not in (adapted_trials[0].params)
+        assert new_param not in (adapted_trials[1].params)
+        assert new_param not in (adapted_trials[2].params)
+
+    def test_dimension_addition_backward_not_existing(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionAddition.backward`
+        with valid param and invalid trials because param does not exist
+        """
+        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        dimension_addition_adapter = DimensionAddition(new_param)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            dimension_addition_adapter.backward(trials)
+        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+
+
+class TestDimensionDeletionForwardBackward(object):
+    """Test :meth:`orion.core.evc.adapters.DimensionDeletion.forward` and
+    :meth:`orion.core.evc.adapters.DimensionDeletion.backward`
+    """
+
+    def test_dimension_deletion_forward(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionDeletion.forward`
+        with valid param and valid trials
+        """
+        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        dimension_deletion_adapter = DimensionDeletion(new_param)
+
+        sampler = DimensionBuilder().build('random', 'uniform(10, 100, discrete=True)')
+        for trial in trials:
+            random_param = new_param.to_dict()
+            random_param['value'] = sampler.sample()
+            trial.params.append(Trial.Param(**random_param))
+
+        adapted_trials = dimension_deletion_adapter.forward(trials)
+        assert len(adapted_trials) == 0
+
+        trials[0].params[-1].value = 1
+        assert trials[0].params[-1] == new_param
+
+        adapted_trials = dimension_deletion_adapter.forward(trials)
+        assert len(adapted_trials) == 1
+
+        trials[4].params[-1].value = 1
+        assert trials[4].params[-1] == new_param
+
+        adapted_trials = dimension_deletion_adapter.forward(trials)
+        assert len(adapted_trials) == 2
+
+        trials[-1].params[-1].value = 1
+        assert trials[-1].params[-1] == new_param
+
+        adapted_trials = dimension_deletion_adapter.forward(trials)
+        assert len(adapted_trials) == 3
+
+        assert new_param not in (adapted_trials[0].params)
+        assert new_param not in (adapted_trials[1].params)
+        assert new_param not in (adapted_trials[2].params)
+
+    def test_dimension_deletion_forward_not_existing(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionDeletion.forward`
+        with valid param and invalid trials because param does not exist
+        """
+        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        dimension_deletion_adapter = DimensionDeletion(new_param)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            dimension_deletion_adapter.forward(trials)
+        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+
+    def test_dimension_deletion_backward(self, dummy_param, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionDeletion.backward`
+        with valid param and valid trials
+        """
+        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        dimension_deletion_adapter = DimensionDeletion(new_param)
+
+        adapted_trials = dimension_deletion_adapter.backward(trials)
+
+        assert adapted_trials[0].params[-1] == new_param
+        assert adapted_trials[4].params[-1] == new_param
+        assert adapted_trials[-1].params[-1] == new_param
+
+    def test_dimension_deletion_backward_already_existing(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionDeletion.backward`
+        with valid param and invalid trials because param already exist
+        """
+        new_param = Trial.Param(name='normal_prior', type='integer', value=1)
+        dimension_deletion_adapter = DimensionDeletion(new_param)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            dimension_deletion_adapter.backward(trials)
+        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+
+
+class TestDimensionPriorChangeForwardBackward(object):
+    """Test :meth:`orion.core.evc.adapters.DimensionPriorChange.forward` and
+    :meth:`orion.core.evc.adapters.DimensionPriorChange.backward`
+    """
+
+    def test_dimension_prior_change_forward(self, large_prior, small_prior, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionPriorChange.forward`
+        with compatible priors
+        """
+        dimension_prior_change_adapter = DimensionPriorChange(
+            'small_prior', small_prior, large_prior)
+
+        adapted_trials = dimension_prior_change_adapter.forward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+    def test_dimension_prior_change_forward_incompatible_dimensions(
+            self, small_prior, disjoint_prior, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionPriorChange.forward`
+        with incompatible priors, such that all trials are filtered out
+        """
+        dimension_prior_change_adapter = DimensionPriorChange(
+            'small_prior', small_prior, disjoint_prior)
+
+        adapted_trials = dimension_prior_change_adapter.forward(trials)
+
+        assert len(adapted_trials) == 0
+
+    def test_dimension_prior_change_backward(self, large_prior, small_prior, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionPriorChange.backward`
+        with compatible priors
+        """
+        dimension_prior_change_adapter = DimensionPriorChange(
+            'large_prior', large_prior, small_prior)
+
+        adapted_trials = dimension_prior_change_adapter.backward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+    def test_dimension_prior_change_backward_incompatible_dimensions(
+            self, disjoint_prior, small_prior, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionPriorChange.backward`
+        with incompatible priors, such that all trials are filtered out
+        """
+        dimension_prior_change_adapter = DimensionPriorChange(
+            'small_prior', disjoint_prior, small_prior)
+
+        adapted_trials = dimension_prior_change_adapter.backward(trials)
+
+        assert len(adapted_trials) == 0
+
+
+class TestDimensionRenamingForwardBackward(object):
+    """Test :meth:`orion.core.evc.adapters.DimensionRenaming.forward` and
+    :meth:`orion.core.evc.adapters.DimensionRenaming.backward`
+    """
+
+    def test_dimension_renaming_forward(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionRenaming.forward`
+        with valid names
+        """
+        old_name = 'small_prior'
+        new_name = 'new_name'
+
+        dimension_renaming_adapter = DimensionRenaming(old_name, new_name)
+
+        adapted_trials = dimension_renaming_adapter.forward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert new_name in [param.name for param in adapted_trials[0].params]
+        assert old_name not in [param.name for param in adapted_trials[0].params]
+
+        assert new_name in [param.name for param in adapted_trials[-1].params]
+        assert old_name not in [param.name for param in adapted_trials[-1].params]
+
+    def test_dimension_renaming_forward_incompatible(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionRenaming.forward`
+        with non existing old name in trials
+        """
+        old_name = 'bad name'
+        new_name = 'small_prior'
+
+        dimension_renaming_adapter = DimensionRenaming(old_name, new_name)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            dimension_renaming_adapter.forward(trials)
+        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+
+    def test_dimension_renaming_backward(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionRenaming.backward`
+        with valid names
+        """
+        old_name = 'old_name'
+        new_name = 'small_prior'
+
+        dimension_renaming_adapter = DimensionRenaming(old_name, new_name)
+
+        adapted_trials = dimension_renaming_adapter.backward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert old_name in [param.name for param in adapted_trials[0].params]
+        assert new_name not in [param.name for param in adapted_trials[0].params]
+
+        assert old_name in [param.name for param in adapted_trials[-1].params]
+        assert new_name not in [param.name for param in adapted_trials[-1].params]
+
+    def test_dimension_renaming_backward_incompatible(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionRenaming.backward`
+        with non existing new name in trials
+        """
+        old_name = 'small_prior'
+        new_name = 'bad name'
+
+        dimension_renaming_adapter = DimensionRenaming(old_name, new_name)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            dimension_renaming_adapter.backward(trials)
+        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+
+
+class TestAlgorithmChangeForwardBackward(object):
+    """Test :meth:`orion.core.evc.adapters.AlgorithmChange.forward` and
+    :meth:`orion.core.evc.adapters.AlgorithmChange.backward`
+    """
+
+    def test_algorithm_change_forward(self, trials):
+        """Test :meth:`orion.core.evc.adapters.AlgorithmChange.forward`"""
+        algorithm_change_adaptor = AlgorithmChange()
+
+        adapted_trials = algorithm_change_adaptor.forward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert adapted_trials[0] is trials[0]
+        assert adapted_trials[-1] is trials[-1]
+
+    def test_algorithm_change_backward(self, trials):
+        """Test :meth:`orion.core.evc.adapters.AlgorithmChange.backward`"""
+        algorithm_change_adaptor = AlgorithmChange()
+
+        adapted_trials = algorithm_change_adaptor.backward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert adapted_trials[0] is trials[0]
+        assert adapted_trials[-1] is trials[-1]
+
+
+class TestCodeChangeForwardBackward(object):
+    """Test :meth:`orion.core.evc.adapters.CodeChange.forward` and
+    :meth:`orion.core.evc.adapters.CodeChange.backward`
+    """
+
+    def test_code_change_forward_noeffect(self, trials):
+        """Test :meth:`orion.core.evc.adapters.CodeChange.forward` with change type NOEFFECT"""
+        code_change_adapter = CodeChange(CodeChange.NOEFFECT)
+
+        adapted_trials = code_change_adapter.forward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert adapted_trials[0] is trials[0]
+        assert adapted_trials[-1] is trials[-1]
+
+    def test_code_change_forward_unsure(self, trials):
+        """Test :meth:`orion.core.evc.adapters.CodeChange.forward` with change type UNSURE"""
+        code_change_adapter = CodeChange(CodeChange.UNSURE)
+
+        adapted_trials = code_change_adapter.forward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert adapted_trials[0] is trials[0]
+        assert adapted_trials[-1] is trials[-1]
+
+    def test_code_change_forward_break(self, trials):
+        """Test :meth:`orion.core.evc.adapters.CodeChange.forward` with change type BREAK"""
+        code_change_adapter = CodeChange(CodeChange.BREAK)
+
+        adapted_trials = code_change_adapter.forward(trials)
+
+        assert len(adapted_trials) == 0
+
+    def test_code_change_backward_noeffect(self, trials):
+        """Test :meth:`orion.core.evc.adapters.CodeChange.backward` with change type NOEFFECT"""
+        code_change_adapter = CodeChange(CodeChange.NOEFFECT)
+
+        adapted_trials = code_change_adapter.backward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert adapted_trials[0] is trials[0]
+        assert adapted_trials[-1] is trials[-1]
+
+    def test_code_change_backward_unsure(self, trials):
+        """Test :meth:`orion.core.evc.adapters.CodeChange.backward` with change type UNSURE"""
+        code_change_adapter = CodeChange(CodeChange.UNSURE)
+
+        adapted_trials = code_change_adapter.backward(trials)
+
+        assert len(adapted_trials) == 0
+
+    def test_code_change_backward_break(self, trials):
+        """Test :meth:`orion.core.evc.adapters.CodeChange.backward` with change type BREAK"""
+        code_change_adapter = CodeChange(CodeChange.BREAK)
+
+        adapted_trials = code_change_adapter.backward(trials)
+
+        assert len(adapted_trials) == 0
+
+
+class TestCompositeAdapterForwardBackward(object):
+    """Test :meth:`orion.core.evc.adapters.CompositeAdapter.forward` and
+    :meth:`orion.core.evc.adapters.CompositeAdapter.backward`
+    """
+
+    def test_composite_adapter_forward_emtpy(self, trials):
+        """Test :meth:`orion.core.evc.adapters.CompositeAdapter.forward` and
+        :meth:`orion.core.evc.adapters.CompositeAdapter.backward` with no adapters
+        """
+        composite_adapter = CompositeAdapter()
+
+        assert len(composite_adapter.forward(trials)) == len(trials)
+        assert len(composite_adapter.backward(trials)) == len(trials)
+
+    def test_composite_adapter_forward(self, dummy_param, trials):
+        """Test :meth:`orion.core.evc.adapters.CompositeAdapter.forward` with two adapters"""
+        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+
+        dimension_addition_adapter = DimensionAddition(new_param)
+        dimension_deletion_adapter = DimensionDeletion(new_param)
+
+        composite_adapter = CompositeAdapter(dimension_addition_adapter)
+
+        adapted_trials = composite_adapter.forward(trials)
+
+        assert adapted_trials[0].params[-1] == new_param
+        assert adapted_trials[4].params[-1] == new_param
+        assert adapted_trials[-1].params[-1] == new_param
+
+        composite_adapter = CompositeAdapter(dimension_addition_adapter, dimension_deletion_adapter)
+
+        adapted_trials = composite_adapter.forward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert new_param not in (adapted_trials[0].params)
+        assert new_param not in (adapted_trials[4].params)
+        assert new_param not in (adapted_trials[-1].params)
+
+    def test_composite_adapter_backward(self, dummy_param, trials):
+        """Test :meth:`orion.core.evc.adapters.CompositeAdapter.backward` with two adapters"""
+        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+
+        dimension_addition_adapter = DimensionAddition(new_param)
+        dimension_deletion_adapter = DimensionDeletion(new_param)
+
+        composite_adapter = CompositeAdapter(dimension_deletion_adapter)
+
+        adapted_trials = composite_adapter.backward(trials)
+
+        assert adapted_trials[0].params[-1] == new_param
+        assert adapted_trials[4].params[-1] == new_param
+        assert adapted_trials[-1].params[-1] == new_param
+
+        composite_adapter = CompositeAdapter(dimension_addition_adapter, dimension_deletion_adapter)
+
+        adapted_trials = composite_adapter.backward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert new_param not in (adapted_trials[0].params)
+        assert new_param not in (adapted_trials[4].params)
+        assert new_param not in (adapted_trials[-1].params)
+
+
+def test_dimension_addition_configuration(dummy_param):
+    """Test :meth:`orion.core.evc.adapters.DimensionAddition.configuration`"""
+    dimension_addition_adapter = DimensionAddition(dummy_param)
+
+    configuration = dimension_addition_adapter.configuration[0]
+
+    assert configuration['of_type'] == "dimensionaddition"
+    assert configuration['param'] == dummy_param.to_dict()
+
+    assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
+
+
+def test_dimension_deletion_configuration(dummy_param):
+    """Test :meth:`orion.core.evc.adapters.DimensionDeletion.configuration`"""
+    dimension_deletion_adapter = DimensionDeletion(dummy_param)
+
+    configuration = dimension_deletion_adapter.configuration[0]
+
+    assert configuration['of_type'] == "dimensiondeletion"
+    assert configuration['param'] == dummy_param.to_dict()
+
+    assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
+
+
+def test_dimension_prior_change_configuration(small_prior, large_prior):
+    """Test :meth:`orion.core.evc.adapters.DimensionPriorChange.configuration`"""
+    dimension_name = 'small_prior'
+    dimension_prior_change_adapter = DimensionPriorChange(dimension_name, small_prior, large_prior)
+
+    configuration = dimension_prior_change_adapter.configuration[0]
+
+    assert configuration['of_type'] == "dimensionpriorchange"
+    assert configuration['name'] == dimension_name
+    assert configuration['old_prior'] == small_prior
+    assert configuration['new_prior'] == large_prior
+
+    assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
+
+
+def test_dimension_renaming_configuration():
+    """Test :meth:`orion.core.evc.adapters.DimensionRenaming.configuration`"""
+    old_name = 'old_name'
+    new_name = 'new_name'
+    dimension_renaming_adapter = DimensionRenaming(old_name, new_name)
+
+    configuration = dimension_renaming_adapter.configuration[0]
+
+    assert configuration['of_type'] == "dimensionrenaming"
+    assert configuration['old_name'] == old_name
+    assert configuration['new_name'] == new_name
+
+    assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
+
+
+def test_algorithm_change_configuration():
+    """Test :meth:`orion.core.evc.adapters.AlgorithmChange.configuration`"""
+    algorithm_change_adaptor = AlgorithmChange()
+
+    configuration = algorithm_change_adaptor.configuration[0]
+
+    assert configuration['of_type'] == "algorithmchange"
+
+    assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
+
+
+def test_code_change_configuration():
+    """Test :meth:`orion.core.evc.adapters.CodeChange.configuration`"""
+    code_change_adaptor = CodeChange(CodeChange.UNSURE)
+
+    configuration = code_change_adaptor.configuration[0]
+
+    assert configuration['of_type'] == "codechange"
+    assert configuration['change_type'] == CodeChange.UNSURE
+
+    assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
+
+
+def test_composite_configuration(dummy_param):
+    """Test :meth:`orion.core.evc.adapters.CompositeAdapter.configuration`"""
+    new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+    dimension_addition_adapter = DimensionAddition(dummy_param)
+    dimension_deletion_adapter = DimensionDeletion(new_param)
+
+    composite_adapter = CompositeAdapter(dimension_addition_adapter, dimension_deletion_adapter)
+
+    configuration = composite_adapter.configuration
+
+    assert configuration[0] == dimension_addition_adapter.configuration[0]
+    assert configuration[1] == dimension_deletion_adapter.configuration[0]
+
+    assert Adapter.build(configuration).adapters[0].configuration[0] == configuration[0]
+    assert Adapter.build(configuration).adapters[1].configuration[0] == configuration[1]

--- a/tests/unittests/core/test_trial.py
+++ b/tests/unittests/core/test_trial.py
@@ -53,6 +53,16 @@ class TestTrial(object):
         with pytest.raises(AttributeError):
             Trial.Value(ispii='iela')
 
+    def test_param_bad_init(self):
+        """Other than `Trial.Param.__slots__` are not allowed in __init__ too."""
+        with pytest.raises(AttributeError):
+            Trial.Param(ispii='iela')
+
+    def test_result_bad_init(self):
+        """Other than `Trial.Result.__slots__` are not allowed in __init__ too."""
+        with pytest.raises(AttributeError):
+            Trial.Result(ispii='iela')
+
     def test_not_allowed_status(self):
         """Other than `Trial.allowed_stati` are not allowed in `Trial.status`."""
         t = Trial()

--- a/tests/unittests/core/test_trial.py
+++ b/tests/unittests/core/test_trial.py
@@ -100,6 +100,14 @@ class TestTrial(object):
         trials = Trial.build(exp_config[1])
         assert list(map(lambda x: x.to_dict(), trials)) == exp_config[1]
 
+    @pytest.mark.usefixtures("clean_db")
+    def test_value_equal(self, exp_config):
+        """Compare Param objects using __eq__"""
+        trials = Trial.build(exp_config[1])
+
+        assert trials[0].params[0] == Trial.Param(**exp_config[1][0]['params'][0])
+        assert trials[0].params[1] != Trial.Param(**exp_config[1][0]['params'][0])
+
     def test_str_trial(self, exp_config):
         """Test representation of `Trial`."""
         t = Trial(**exp_config[1][2])


### PR DESCRIPTION
Depends on #86 

Why:

Experiment branches because of changes in the configuration or
the user's code. This make experiments incompatible with one another
unless we define adapters such that a branched experiment B can access
trials from parent experiment A.

How:

Adapters have two main methods, forward and backward. The method forward
defines how trials from parent experiment A are filtered or adapted to
be compatible with experiment B. Modifications are only applied at
execution time and are not saved anywhere in the database. Adapters only
provides a *view* on an experiment.

There is adapters for

* Dimension addition
* Dimension deletion
* Dimension renaming
* Change of dimension prior
* Change of algorithm
* Change of code
* Combining different adapters

Adapters all have a `to_dict` method which provides sufficient
information to rebuild the adapter. This is to facilitate save of
adapters in a database and retrieval.

Adapters can be build using the factory class Adapter(**kwargs) or using
Adapter.build(list_of_dicts).