### PR TITLE
Add tree data structure for EVC 

### DIFF
--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -1,0 +1,391 @@
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.evc.tree` -- Tree data structure for the experiment version control system
+===========================================================================================
+
+.. module:: evc
+   :platform: Unix
+   :synopsis: Tree data structure for the experiment version control system
+
+Experiment version control requires building trees of the experiments so
+that we can fetch trials from one experiment to another or navigate from
+one experiment to another to visualise different statistics.
+
+TreeNode and tree iterators support the tree data structure of the experiment version control.
+TreeNode is a generic class which can carry arbitrary python objects. It comes with basic methods to
+set parent and children. A method `map` allows to apply functions recursively on the tree in a
+generic manner.
+
+"""
+
+
+class PreOrderTraversal(object):
+    """Iterate on a tree in a pre-order traversal fashion
+
+    Attributes
+    ----------
+    stack: list of `orion.core.evc.tree.TreeNode`
+        Nodes logged during iteration
+
+    """
+
+    __slots__ = ('stack', )
+
+    def __init__(self, tree_node):
+        """Initialize the stack for iteration"""
+        self.stack = [tree_node]
+
+    def __iter__(self):
+        """Get the iterator"""
+        return self
+
+    def __next__(self):
+        """Get the next node in pre-order traversal"""
+        try:
+            node = self.stack.pop()
+        except IndexError:
+            raise StopIteration
+
+        self.stack += node.children[::-1]
+
+        return node
+
+
+class DepthFirstTraversal(object):
+    """Iterate on a tree in a pre-order traversal fashion
+
+    Attributes
+    ----------
+    stack: list of `orion.core.evc.tree.TreeNode`
+        Nodes logged during iteration
+    seen: set of `orion.core.evc.tree.TreeNode`
+        Nodes which have been returned during iteration
+
+    """
+
+    __slots__ = ('stack', 'seen')
+
+    def __init__(self, tree_node):
+        """Initialize the stack and set of seen nodes for iteration"""
+        self.stack = [tree_node]
+        self.seen = set()
+
+    def _compute_potential(self):
+        """Filter out seen nodes from the stack"""
+        if len(self.stack) == 0:
+            return []
+
+        return list(filter(lambda n: n not in self.seen, self.stack[-1].children))
+
+    def __iter__(self):
+        """Get the iterator"""
+        return self
+
+    def __next__(self):
+        """Get the next node in depth-first traversal"""
+        potential = self._compute_potential()
+        while len(self.stack) > 0 and len(potential) > 0:
+            self.stack += potential[::-1]
+            potential = self._compute_potential()
+
+        try:
+            node = self.stack.pop()
+        except IndexError:
+            raise StopIteration
+
+        self.seen.add(node)
+
+        return node
+
+
+class TreeNode(object):
+    r"""Tree node data structure
+
+    Nodes have an attribute item to carry arbitrary information. A node may only have one parent and
+    can have as many children as desired.
+
+    Parents can be set at initialiation or via `node.set_parent`. Setting a parent automatically set
+    the current node as the child of the parent.
+
+    Children can be set at initialiation or via `node.add_children`. Setting children automatically
+    set their parent as the current node.
+
+    Tree of nodes are iterable, by default with preorder traversal.
+
+    .. seealso::
+        `orion.core.evc.tree.PreOrderTraversal`
+        `orion.core.evc.tree.DepthFirstTraversal`
+
+    Attributes
+    ----------
+    item: object
+        Can be anything
+    parent: None or instance of `orion.core.evc.tree.TreeNode`
+        The parent of the current node, None if the current node is the root.
+    children: None or list of instances of `orion.core.evc.tree.TreeNode`
+        The children of the curent node.
+    root: instance of `orion.core.evc.tree.TreeNode`
+        The top node of the current tree. The root node returns itself.
+
+    Example
+    -------
+    .. code-block:: python
+        :linenos:
+
+        a = TreeNode("a")
+        b = TreeNode("b", a)
+        c = TreeNode("c", a)
+        d = TreeNode("d", a)
+        e = TreeNode("e", a)
+
+        f = TreeNode("f", b)
+        g = TreeNode("g", b)
+
+        h = TreeNode("h", e)
+
+        # Gives this tree
+        # a
+        # |   \  \   \
+        # b    c  d   e
+        # | \         |
+        # f  g        h
+
+        g.set_parent(e)
+
+        # Gives this tree
+        # a
+        # |  \  \   \
+        # b   c  d   e
+        # |          | \
+        # f          h g
+
+        c.add_children(h, g)
+
+        # Gives this tree
+        # a
+        # |  \    \   \
+        # b   c    d   e
+        # |   | \
+        # f   h  g
+
+        a.drop_children(c)
+
+        # Gives this tree
+        # a
+        # |  \   \
+        # b   d   e
+        # |
+        # f
+
+    """
+
+    __slots__ = ('_item', '_parent', '_children')
+
+    def __init__(self, item, parent=None, children=tuple()):
+        """Initialize node with item, parent and children
+
+        .. seealso::
+            :class:`orion.core.evc.tree.TreeNode` for information about the attributes
+        """
+        self._item = item
+        self._parent = None
+        self._children = []
+
+        self.set_parent(parent)
+        self.add_children(*children)
+
+    @property
+    def item(self):
+        """Get item of the node which may contain arbitrary objects"""
+        return self._item
+
+    @item.setter
+    def item(self, new_item):
+        """Set item of the node with arbitrary objects"""
+        self._item = new_item
+
+    @property
+    def parent(self):
+        """Get parent of the node, None if no parent"""
+        return self._parent
+
+    def drop_parent(self):
+        """Drop the parent of the node, do nothing if no parent
+
+        Note that the node will be removed from the children of the parent as well
+        """
+        if self.parent is not None:
+            self._parent.drop_children(self)
+
+    def set_parent(self, node):
+        """Set the parent of the node
+
+        Note that setting a new parent will have the effect of dropping the previous parent, hence
+        dropping this current node from the previous parent's children list.
+
+        .. seealso::
+            `orion.core.evc.tree.TreeNode.drop_parent`
+        """
+        if node is self.parent:
+            return
+
+        if node is not None and not isinstance(node, TreeNode):
+            raise TypeError("Cannot set parent to %s" % str(node))
+
+        if self.parent is not None:
+            self.drop_parent()
+
+        if node is not None:
+            node.add_children(self)
+
+    @property
+    def children(self):
+        """Get children of the node, empty list if no children"""
+        return self._children
+
+    def drop_children(self, *nodes):
+        """Drop the children of the node, do nothing if no parent
+
+        Note that the parent of the given node will be removed as well
+
+        Raises
+        ------
+        ValueError
+            If one of the given nodes is not a children of the current node.
+
+        """
+        for child in nodes:
+            del self._children[self.children.index(child)]
+            child._parent = None
+
+    def add_children(self, *nodes):
+        """Add children to the current node
+
+        Note that added children will have their parent set to the current node as well.
+
+        .. seealso::
+            `orion.core.evc.tree.TreeNode.drop_children`
+        """
+        for child in nodes:
+            if child is not None and not isinstance(child, TreeNode):
+                raise TypeError("Cannot add %s to children" % str(child))
+
+            if child not in self._children:
+                # TreeNode.set_parent uses add_children so using it here could cause an infinit
+                # recursion. add_children() gets the dirty job done.
+                child.drop_parent()
+                child._parent = self
+                self._children.append(child)
+
+    @property
+    def root(self):
+        """Get the root of the tree
+
+        Root node returns itself
+        """
+        if self.parent is None:
+            return self
+
+        return self.parent.root
+
+    def map(self, function, node):
+        r"""Apply a function recursively on the tree
+
+        The function can be applied upwards on parents or downwards on children. The direction is
+        defined by passing self.parent or self.children as the node argument.
+
+        Parameters
+        ----------
+        function : callable
+            Callable object to which will be passed current node plus the parent node of children
+            nodes of the result down or up the tree respectively
+            If map on parents, callable(self, rval_parent_node)
+            If map on children, callable(self, rval_children_nodes)
+        node: None, `orion.core.evc.TreeNode` or list
+            Can be either
+            `None`: function is applied on current node only
+            `self.parent`: function is applied recursively climbing up the tree until the root
+            `self.children`: function is applied recursively going down the tree until the leafs
+
+        Examples
+        --------
+        .. code-block:: python
+            :linenos:
+
+            # Tree structure
+            # a
+            # |   \  \   \
+            # b    c  d   e
+            # | \         |
+            # f  g        h
+            #
+
+            root = TreeNode(1)
+            b = TreeNode(1, root)
+            TreeNode(1, root)
+            TreeNode(1, root)
+            e = TreeNode(1, root)
+
+            f = TreeNode(1, b)
+            TreeNode(1, b)
+
+            h = TreeNode(1, e)
+
+            def increment(node, children):
+                for child in TreeNode(0, None, children):
+                    child.item += 1
+
+                return node.item + 1
+
+            # Should return
+            #
+            # 2
+            # |   \  \   \
+            # 3    3  3   3
+            # | \         |
+            # 4  4        4
+
+            rval = root.map(increment, root.children)
+            assert [node.item for node in rval] == [2, 3, 4, 4, 3, 3, 3, 4]
+
+            def increment_parent(node, parent):
+                if parent is not None:
+                    for parent in parent.root:
+                        parent.item += 1
+
+                return node.item + 1
+
+            # Should return
+            #
+            # 4
+            # |
+            # 3
+            # |
+            # 2
+
+            rval = f.map(increment_parent, f.parent)
+            assert [node.item for node in rval.root] == [4, 3, 2]
+
+            rval = h.map(increment_parent, h.parent)
+            assert [node.item for node in rval.root] == [4, 3, 2]
+
+        """
+        if node is None:
+            return TreeNode(function(self, None))
+        elif node is self.parent:
+            rval_node = node.map(function, node.parent)
+            return TreeNode(function(self, rval_node), rval_node)
+        elif node is self.children:
+            rval_nodes = [child.map(function, child.children) for child in self.children]
+            return TreeNode(function(self, rval_nodes), parent=None, children=rval_nodes)
+        else:
+            raise TypeError("Invalid nodes: %s" % str(node))
+
+    def __iter__(self):
+        """Iterate on the tree with pre-order traversal"""
+        return PreOrderTraversal(self)
+
+
+def flattened(trials_tree):
+    """Get a list of the tree items in pre-order traversal"""
+    return [node.item for node in trials_tree]

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -385,13 +385,16 @@ class TreeNode(object):
 
         """
         if node is None:
-            return TreeNode(function(self, None))
+            rval, _ = function(self, None)
+            return TreeNode(rval)
         elif node is self.parent:
-            rval_node = node.map(function, node.parent)
-            return TreeNode(function(self, rval_node), rval_node)
+            rval_parent_node = node.map(function, node.parent)
+            rval, parent_node = function(self, rval_parent_node)
+            return TreeNode(rval, parent_node)
         elif node is self.children:
-            rval_nodes = [child.map(function, child.children) for child in self.children]
-            return TreeNode(function(self, rval_nodes), parent=None, children=rval_nodes)
+            rval_children_nodes = [child.map(function, child.children) for child in self.children]
+            rval, children_nodes = function(self, rval_children_nodes)
+            return TreeNode(rval, parent=None, children=children_nodes)
         else:
             raise TypeError("Invalid nodes: %s" % str(node))
 

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -248,6 +248,8 @@ class TreeNode(object):
     def drop_children(self, *nodes):
         """Drop the children of the node, do nothing if no parent
 
+        If no nodes are passed, the method will drop all the children of the current node.
+
         Note that the parent of the given node will be removed as well
 
         Raises
@@ -256,7 +258,10 @@ class TreeNode(object):
             If one of the given nodes is not a children of the current node.
 
         """
-        for child in nodes:
+        if not nodes:
+            nodes = self.children
+
+        for child in list(nodes):
             del self._children[self.children.index(child)]
             # pylint: disable=protected-access
             child._parent = None

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -19,6 +19,7 @@ generic manner.
 """
 
 
+# pylint: disable=too-few-public-methods
 class PreOrderTraversal(object):
     """Iterate on a tree in a pre-order traversal fashion
 
@@ -51,6 +52,7 @@ class PreOrderTraversal(object):
         return node
 
 
+# pylint: disable=too-few-public-methods
 class DepthFirstTraversal(object):
     """Iterate on a tree in a pre-order traversal fashion
 
@@ -72,7 +74,7 @@ class DepthFirstTraversal(object):
 
     def _compute_potential(self):
         """Filter out seen nodes from the stack"""
-        if len(self.stack) == 0:
+        if not self.stack:
             return []
 
         return list(filter(lambda n: n not in self.seen, self.stack[-1].children))
@@ -84,7 +86,7 @@ class DepthFirstTraversal(object):
     def __next__(self):
         """Get the next node in depth-first traversal"""
         potential = self._compute_potential()
-        while len(self.stack) > 0 and len(potential) > 0:
+        while self.stack and potential:
             self.stack += potential[::-1]
             potential = self._compute_potential()
 
@@ -256,6 +258,7 @@ class TreeNode(object):
         """
         for child in nodes:
             del self._children[self.children.index(child)]
+            # pylint: disable=protected-access
             child._parent = None
 
     def add_children(self, *nodes):
@@ -269,6 +272,12 @@ class TreeNode(object):
         for child in nodes:
             if child is not None and not isinstance(child, TreeNode):
                 raise TypeError("Cannot add %s to children" % str(child))
+
+            # TreeNode.set_parent uses add_children so using it here could cause an infinit
+            # recursion. add_children() gets the dirty job done.
+            child.drop_parent()
+            # pylint: disable=protected-access
+            child._parent = self
 
             if child not in self._children:
                 # TreeNode.set_parent uses add_children so using it here could cause an infinit

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -394,7 +394,7 @@ class TreeNode(object):
             rval, children_nodes = function(self, rval_children_nodes)
             return TreeNode(rval, parent=None, children=children_nodes)
         else:
-            raise TypeError("Invalid nodes: %s" % str(node))
+            raise ValueError("Invalid nodes: %s" % str(node))
 
     def __iter__(self):
         """Iterate on the tree with pre-order traversal"""

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -347,7 +347,7 @@ class TreeNode(object):
                 for child in TreeNode(0, None, children):
                     child.item += 1
 
-                return node.item + 1
+                return node.item + 1, children
 
             # Should return
             #
@@ -365,7 +365,7 @@ class TreeNode(object):
                     for parent in parent.root:
                         parent.item += 1
 
-                return node.item + 1
+                return node.item + 1, parent
 
             # Should return
             #

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -306,10 +306,13 @@ class TreeNode(object):
         Parameters
         ----------
         function : callable
-            Callable object to which will be passed current node plus the parent node of children
-            nodes of the result down or up the tree respectively
+            Callable object to which will be passed the current node plus the parent node or the
+            children nodes, depending on the direction of function application.
             If map on parents, callable(self, rval_parent_node)
-            If map on children, callable(self, rval_children_nodes)
+            If map on children, callable(self, rval_children_nodes).
+            Note that the callable object is expected to return an object which will be set as the
+            current node's item (in the resulting tree), and the parent node or the children nodes
+            depending on the direction of function application.
         node: None, `orion.core.evc.TreeNode` or list
             Can be either
             `None`: function is applied on current node only

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -402,6 +402,17 @@ class TreeNode(object):
         """Iterate on the tree with pre-order traversal"""
         return PreOrderTraversal(self)
 
+    def __repr__(self):
+        """Represent the object as a string."""
+        parent = self.parent
+        if parent is not None:
+            parent = parent.item
+
+        children = [child.item for child in self.children]
+
+        return ("%s(%s, parent=%s, children=%s)" %
+                (self.__class__.__name__, str(self.item), str(parent), str(children)))
+
 
 def flattened(trials_tree):
     """Get a list of the tree items in pre-order traversal"""

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -278,16 +278,11 @@ class TreeNode(object):
             if child is not None and not isinstance(child, TreeNode):
                 raise TypeError("Cannot add %s to children" % str(child))
 
-            # TreeNode.set_parent uses add_children so using it here could cause an infinit
-            # recursion. add_children() gets the dirty job done.
-            child.drop_parent()
-            # pylint: disable=protected-access
-            child._parent = self
-
             if child not in self._children:
                 # TreeNode.set_parent uses add_children so using it here could cause an infinit
                 # recursion. add_children() gets the dirty job done.
                 child.drop_parent()
+                # pylint: disable=protected-access
                 child._parent = self
                 self._children.append(child)
 

--- a/tests/unittests/core/evc/test_tree.py
+++ b/tests/unittests/core/evc/test_tree.py
@@ -1,0 +1,423 @@
+"""Test for generic :class:`orion.core.evc.tree`"""
+
+from orion.core.evc.tree import DepthFirstTraversal, flattened, PreOrderTraversal, TreeNode
+
+
+def test_node_creation():
+    """Test empty initialization of tree node"""
+    TreeNode("test")
+    TreeNode("test", None, tuple())
+
+
+def test_node_creation_with_parent():
+    """Test assignement of parent on initialization"""
+    parent = TreeNode("test")
+    child = TreeNode("test", parent)
+
+    assert child.parent is parent
+
+    assert parent.children[0] is child
+
+
+def test_node_set_parent():
+    """Test assignement of parent"""
+    parent = TreeNode("test")
+    child = TreeNode("test")
+
+    child.set_parent(parent)
+
+    assert child.parent is parent
+
+    assert parent.children[0] is child
+
+
+def test_node_set_no_parent():
+    """Test assignement of no parent, meaning droping the parent"""
+    parent = TreeNode("test")
+    child = TreeNode("test")
+
+    child.set_parent(parent)
+
+    assert child.parent is parent
+    assert parent.children[0] is child
+
+    child.set_parent(None)
+
+    assert child.parent is None
+    assert len(parent.children) == 0
+
+
+def test_node_drop_parent():
+    """Test dropping parent"""
+    parent = TreeNode("test")
+    child = TreeNode("test")
+
+    child.set_parent(parent)
+
+    assert child.parent is parent
+    assert parent.children[0] is child
+
+    child.drop_parent()
+
+    assert child.parent is None
+    assert len(parent.children) == 0
+
+
+def test_node_add_child():
+    """Test assignement of child"""
+    parent = TreeNode("test")
+    child = TreeNode("test")
+
+    parent.add_children(child)
+
+    assert parent.children[0] is child
+    assert child.parent is parent
+
+
+def test_node_remove_child():
+    """Test removing child"""
+    parent = TreeNode("test")
+    child = TreeNode("test")
+
+    parent.add_children(child)
+
+    assert child.parent is parent
+    assert parent.children[0] is child
+
+    parent.drop_children(child)
+
+    assert len(parent.children) == 0
+    assert child.parent is None
+
+
+def test_node_add_children():
+    """Test assignement of children"""
+    parent = TreeNode("test")
+    child1 = TreeNode("test1")
+    child2 = TreeNode("test2")
+
+    parent.add_children(child1, child2)
+
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+    assert child1.parent is parent
+    assert child2.parent is parent
+
+
+def test_node_remove_children_sequentially():
+    """Test removing children one after the other"""
+    parent = TreeNode("test")
+    child1 = TreeNode("test1")
+    child2 = TreeNode("test2")
+
+    parent.add_children(child1, child2)
+
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+    assert child1.parent is parent
+    assert child2.parent is parent
+
+    parent.drop_children(child1)
+
+    assert len(parent.children) == 1
+    assert child1.parent is None
+    assert parent.children[0] is child2
+    assert child2.parent is parent
+
+    parent.drop_children(child2)
+
+    assert len(parent.children) == 0
+    assert child1.parent is None
+    assert child2.parent is None
+
+
+def test_node_remove_children_in_batch():
+    """Test removing children all at the same time"""
+    parent = TreeNode("test")
+    child1 = TreeNode("test1")
+    child2 = TreeNode("test2")
+
+    parent.add_children(child1, child2)
+
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+    assert child1.parent is parent
+    assert child2.parent is parent
+
+    parent.drop_children(child1, child2)
+
+    assert len(parent.children) == 0
+    assert child1.parent is None
+    assert child2.parent is None
+
+
+def test_parent_parent():
+    """Test path through two level of parents"""
+    grand_parent = TreeNode("test")
+    parent = TreeNode("test", grand_parent)
+    child = TreeNode("test", parent)
+
+    assert child.parent is parent
+    assert child.parent.parent is grand_parent
+    assert grand_parent.children[0] is parent
+    assert grand_parent.children[0].children[0] is child
+
+
+def test_children_children():
+    """Test path through two level of children"""
+    child = TreeNode("test")
+    parent = TreeNode("test", children=[child])
+    grand_parent = TreeNode("test", children=[parent])
+
+    assert child.parent is parent
+    assert child.parent.parent is grand_parent
+    assert grand_parent.children[0] is parent
+    assert grand_parent.children[0].children[0] is child
+
+
+def test_root():
+    """Test root access from leaf"""
+    child = TreeNode("test")
+    parent = TreeNode("test", children=[child])
+    grand_parent = TreeNode("test", children=[parent])
+
+    assert child.root is grand_parent
+    assert child.root is parent.root
+    assert grand_parent.root is grand_parent
+
+
+def test_node_parent_reinsertion():
+    """Test that replacing a parent with the same one does not change anything"""
+    parent = TreeNode("test")
+    child1 = TreeNode("test", parent)
+    child2 = TreeNode("test", parent)
+
+    assert child1.parent is parent
+    assert child2.parent is parent
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+
+    child1.set_parent(parent)
+
+    assert child1.parent is parent
+    assert child2.parent is parent
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+
+    child2.set_parent(parent)
+
+    assert child1.parent is parent
+    assert child2.parent is parent
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+
+
+def test_node_children_reinsertion():
+    """Test that replacing a children with the same one does not change anything"""
+    parent = TreeNode("test")
+    child1 = TreeNode("test", parent)
+    child2 = TreeNode("test", parent)
+
+    assert child1.parent is parent
+    assert child2.parent is parent
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+
+    parent.add_children(child1)
+
+    assert child1.parent is parent
+    assert child2.parent is parent
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+
+    parent.add_children(child2)
+
+    assert child1.parent is parent
+    assert child2.parent is parent
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+
+
+def test_node_set_parent_drop_children():
+    """Test that replacing a parent removes the node from parent's children"""
+    grand_parent = TreeNode("test")
+    parent = TreeNode("test", grand_parent)
+    child = TreeNode("test", parent)
+
+    assert child.parent is parent
+    assert child.parent.parent is grand_parent
+    assert grand_parent.children[0] is parent
+    assert grand_parent.children[0].children[0] is child
+
+    # That's silly...
+    child.set_parent(grand_parent)
+
+    assert child.parent is grand_parent
+    assert len(grand_parent.children) == 2
+    assert grand_parent.parent is None
+    assert len(parent.children) == 0
+    assert parent.parent is grand_parent
+
+
+def test_node_add_children_drop_children():
+    """Test that replacing a children removes the node from previous parent's children"""
+    grand_parent = TreeNode("test")
+    parent = TreeNode("test", grand_parent)
+    child = TreeNode("test", parent)
+
+    assert child.parent is parent
+    assert child.parent.parent is grand_parent
+    assert grand_parent.children[0] is parent
+    assert grand_parent.children[0].children[0] is child
+
+    # That's silly...
+    grand_parent.add_children(child)
+
+    assert child.parent is grand_parent
+    assert len(grand_parent.children) == 2
+    assert grand_parent.parent is None
+    assert len(parent.children) == 0
+    assert parent.parent is grand_parent
+
+
+def test_preorder_traversal():
+    """Test order retrieval of DepthFirstTraversal"""
+    # a
+    # |   \  \   \
+    # b    c  d   e
+    # | \         |
+    # f  g        h
+    root = TreeNode("a")
+    b = TreeNode("b", root)
+    TreeNode("c", root)
+    TreeNode("d", root)
+    e = TreeNode("e", root)
+
+    TreeNode("f", b)
+    TreeNode("g", b)
+
+    TreeNode("h", e)
+
+    rval = [node.item for node in PreOrderTraversal(root)]
+    assert rval == ['a', 'b', 'f', 'g', 'c', 'd', 'e', 'h']
+
+
+def test_depth_first_traversal():
+    """Test order retrieval of DepthFirstTraversal"""
+    # a
+    # |   \  \   \
+    # b    c  d   e
+    # | \         |
+    # f  g        h
+    root = TreeNode("a")
+    b = TreeNode("b", root)
+    TreeNode("c", root)
+    TreeNode("d", root)
+    e = TreeNode("e", root)
+
+    TreeNode("f", b)
+    TreeNode("g", b)
+
+    TreeNode("h", e)
+
+    rval = [node.item for node in DepthFirstTraversal(root)]
+    assert rval == ['f', 'g', 'b', 'c', 'd', 'h', 'e', 'a']
+
+
+def test_map_children():
+    """Test recursive application of map on children"""
+    # a
+    # |   \  \   \
+    # b    c  d   e
+    # | \         |
+    # f  g        h
+    #
+    # Should become
+    #
+    # 2
+    # |   \  \   \
+    # 3    3  3   3
+    # | \         |
+    # 4  4        4
+
+    root = TreeNode(1)
+    b = TreeNode(1, root)
+    TreeNode(1, root)
+    TreeNode(1, root)
+    e = TreeNode(1, root)
+
+    TreeNode(1, b)
+    TreeNode(1, b)
+
+    TreeNode(1, e)
+
+    def increment(node, children):
+        for child in TreeNode(0, None, children):
+            child.item += 1
+
+        return node.item + 1
+
+    rval = root.map(increment, root.children)
+    assert [node.item for node in rval] == [2, 3, 4, 4, 3, 3, 3, 4]
+
+
+def test_map_parent():
+    """Test recursive application of map on parents"""
+    # a
+    # |   \  \   \
+    # b    c  d   e
+    # | \         |
+    # f  g        h
+    #
+    # Will give
+    #
+    # 4
+    # |
+    # 3
+    # |
+    # 2
+
+    root = TreeNode(1)
+    b = TreeNode(1, root)
+    TreeNode(1, root)
+    TreeNode(1, root)
+    e = TreeNode(1, root)
+
+    f = TreeNode(1, b)
+    TreeNode(1, b)
+
+    h = TreeNode(1, e)
+
+    def increment_parent(node, parent):
+        if parent is not None:
+            for parent in parent.root:
+                parent.item += 1
+
+        return node.item + 1
+
+    rval = f.map(increment_parent, f.parent)
+    assert [node.item for node in rval.root] == [4, 3, 2]
+
+    rval = h.map(increment_parent, h.parent)
+    assert [node.item for node in rval.root] == [4, 3, 2]
+
+
+def test_flattened():
+    """Test flattened tree into a list, retrieving items"""
+    # a
+    # |   \  \   \
+    # b    c  d   e
+    # | \         |
+    # f  g        h
+    root = TreeNode("a")
+    b = TreeNode("b", root)
+    TreeNode("c", root)
+    TreeNode("d", root)
+    e = TreeNode("e", root)
+
+    TreeNode("f", b)
+    TreeNode("g", b)
+
+    TreeNode("h", e)
+
+    assert flattened(root) == ['a', 'b', 'f', 'g', 'c', 'd', 'e', 'h']

--- a/tests/unittests/core/evc/test_tree.py
+++ b/tests/unittests/core/evc/test_tree.py
@@ -375,7 +375,7 @@ def test_map_children():
         for child in TreeNode(0, None, children):
             child.item += 1
 
-        return node.item + 1
+        return node.item + 1, children
 
     rval = root.map(increment, root.children)
     assert [node.item for node in rval] == [2, 3, 4, 4, 3, 3, 3, 4]
@@ -413,7 +413,7 @@ def test_map_parent():
             for parent in parent.root:
                 parent.item += 1
 
-        return node.item + 1
+        return node.item + 1, parent
 
     rval = f.map(increment_parent, f.parent)
     assert [node.item for node in rval.root] == [4, 3, 2]

--- a/tests/unittests/core/evc/test_tree.py
+++ b/tests/unittests/core/evc/test_tree.py
@@ -151,6 +151,26 @@ def test_node_remove_children_in_batch():
     assert child2.parent is None
 
 
+def test_node_remove_all_children():
+    """Test drop_children() drops all of them"""
+    parent = TreeNode("test")
+    child1 = TreeNode("test1")
+    child2 = TreeNode("test2")
+
+    parent.add_children(child1, child2)
+
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+    assert child1.parent is parent
+    assert child2.parent is parent
+
+    parent.drop_children()
+
+    assert len(parent.children) == 0
+    assert child1.parent is None
+    assert child2.parent is None
+
+
 def test_parent_parent():
     """Test path through two level of parents"""
     grand_parent = TreeNode("test")


### PR DESCRIPTION
Why:

Experiment version control requires building trees of the experiments so
that we can fetch trials from one experiment to another or navigate from
one experiment to another to visualise different statistics.

How:

Implement a simple TreeNode and tree iterators to support the tree data
structure of the experiment version control. TreeNode is a generic class
which can carry arbitrary python objects. It comes we basic methods to
set parent and children. A method `map` allows to apply functions
recursively on the tree in a generic manner.