### PR TITLE
 Add ExperimentView and ReadOnlyDB wrapper

### DIFF
--- a/src/orion/core/io/database/__init__.py
+++ b/src/orion/core/io/database/__init__.py
@@ -209,6 +209,36 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
         pass
 
 
+# pylint: disable=too-few-public-methods
+class ReadOnlyDB(object):
+    """Read-only view on a database.
+
+    .. seealso::
+
+        :py:class:`orion.core.io.database.AbstractDB`
+    """
+
+    __slots__ = ('_database', )
+
+    #                     Attributes
+    valid_attributes = (["host", "name", "port", "username", "password"] +
+                        # Properties
+                        ["is_connected"] +
+                        # Methods
+                        ["initiate_connection", "close_connection", "read", "count"])
+
+    def __init__(self, database):
+        """Init method, see attributes of :class:`AbstractDB`."""
+        self._database = database
+
+    def __getattr__(self, attr):
+        """Get attribute only if valid"""
+        if attr not in self.valid_attributes:
+            raise AttributeError("Cannot access attribute %s on view-only experiments." % attr)
+
+        return getattr(self._database, attr)
+
+
 class DatabaseError(RuntimeError):
     """Exception type used to delegate responsibility from any database
     implementation's own Exception types.

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -495,13 +495,12 @@ class ExperimentView(object):
     def __init__(self, name):
         """Initialize viewed experiment object with primary key (:attr:`name`, :attr:`user`).
 
-        Try to find an entry in `Database` with such a key and config this object
-        from it import, if successful. Else, init with default/empty values and
-        insert new entry with this object's attributes in database.
+        Build an experiment from configuration found in `Database` with a key (name, user).
 
         .. note::
 
             A view is fully configured at initialiation. It cannot be reconfigured.
+            If no experiment is found for the key (name, user), a `ValueError` will be raised.
 
         :param name: Describe a configuration with a unique identifier per :attr:`user`.
         :type name: str

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -488,7 +488,7 @@ class ExperimentView(object):
     #                     Attributes
     valid_attributes = (["_id", "name", "refers", "metadata", "pool_size", "max_trials", "status"] +
                         # Properties
-                        ["space", "algorithms", "stats"] +
+                        ["space", "algorithms", "stats", "configuration"] +
                         # Methods
                         ["fetch_completed_trials"])
 

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -501,13 +501,19 @@ class ExperimentView(object):
 
         .. note::
 
-            A view is **note** initializable. It is meant to access trials and statistics from the
-            experiment..
+            A view is fully configured at initialiation. It cannot be reconfigured.
 
         :param name: Describe a configuration with a unique identifier per :attr:`user`.
         :type name: str
         """
         self._experiment = Experiment(name)
+
+        if self._experiment.status is None:
+            raise ValueError("No experiment with given name '%s' for user '%s' inside database, "
+                             "no view can be created." %
+                             (self._experiment.name, self._experiment.metadata['user']))
+
+        self._experiment.configure(self._experiment.configuration)
         self._experiment._db = ReadOnlyDB(self._experiment._db)
 
     def __getattr__(self, name):

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -15,7 +15,7 @@ import getpass
 import logging
 import random
 
-from orion.core.io.database import Database
+from orion.core.io.database import Database, ReadOnlyDB
 from orion.core.io.space_builder import SpaceBuilder
 from orion.core.utils.format_trials import trial_to_tuple
 from orion.core.worker.primary_algo import PrimaryAlgo
@@ -471,3 +471,66 @@ class Experiment(object):
                 break
 
         return is_diff
+
+
+# pylint: disable=too-few-public-methods
+class ExperimentView(object):
+    """Non-writable view of an experiment
+
+    .. seealso::
+
+        :py:class:`orion.core.worker.experiment.Experiment` for writable experiments.
+
+    """
+
+    __slots__ = ('_experiment', )
+
+    #                     Attributes
+    valid_attributes = (["_id", "name", "refers", "metadata", "pool_size", "max_trials", "status"] +
+                        # Properties
+                        ["space", "algorithms", "stats"] +
+                        # Methods
+                        ["fetch_completed_trials"])
+
+    def __init__(self, name):
+        """Initialize viewed experiment object with primary key (:attr:`name`, :attr:`user`).
+
+        Try to find an entry in `Database` with such a key and config this object
+        from it import, if successful. Else, init with default/empty values and
+        insert new entry with this object's attributes in database.
+
+        .. note::
+
+            A view is **note** initializable. It is meant to access trials and statistics from the
+            experiment..
+
+        :param name: Describe a configuration with a unique identifier per :attr:`user`.
+        :type name: str
+        """
+        self._experiment = Experiment(name)
+        self._experiment._db = ReadOnlyDB(self._experiment._db)
+
+    def __getattr__(self, name):
+        """Get attribute only if valid"""
+        if name not in self.valid_attributes:
+            raise AttributeError("Cannot access attribute %s on view-only experiments." % name)
+
+        return getattr(self._experiment, name)
+
+    @property
+    def is_done(self):
+        """Return True, if this experiment is considered to be finished.
+
+        Note that call to this property will **not** change the status of the experiment in the
+        database. Only writable :class:`orion.core.worker.experiment.Experiment` would do so.
+
+        .. seealso::
+            :attr:`orion.core.worker.experiment.Experiment.is_done`
+        """
+        query = dict(
+            experiment=self._id,
+            status='completed'
+            )
+        num_completed_trials = self._experiment._db.count('trials', query)
+
+        return num_completed_trials >= self.max_trials

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -538,4 +538,4 @@ class ExperimentView(object):
             )
         num_completed_trials = self._experiment._db.count('trials', query)
 
-        return num_completed_trials >= self.max_trials
+        return num_completed_trials >= self.max_trials or self.algorithms.is_done

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -313,7 +313,11 @@ class Experiment(object):
         experiment._instantiate_config(self.configuration)
         experiment._instantiate_config(config)
         experiment._init_done = True
-        experiment.status = 'pending'
+
+        # If experiment is new or non-branching parameters have been changed such that the status is
+        # not 'done' anymore
+        if experiment.status is None or (experiment.status != 'broken' and not experiment.is_done):
+            experiment.status = 'pending'
 
         # If status is None in this object, then database did not hit a config
         # with same (name, user's name) pair. Everything depends on the user's
@@ -334,7 +338,7 @@ class Experiment(object):
         self._instantiate_config(final_config)
 
         self._init_done = True
-        self.status = 'pending'
+        self.status = experiment.status
 
         # If everything is alright, push new config to database
         if is_new:

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -114,3 +114,23 @@ def hacked_exp(with_user_dendi, random_dt, clean_db):
     exp = Experiment('supernaedo2')
     exp._id = 'supernaedo2'  # white box hack
     return exp
+
+
+@pytest.fixture()
+def trial_id_substitution(with_user_tsirif, random_dt, clean_db):
+    """Replace trial ids by the actual ids of the experiments."""
+    try:
+        Database(of_type='MongoDB', name='orion_test',
+                 username='user', password='pass')
+    except (TypeError, ValueError):
+        pass
+
+    db = Database()
+    experiments = db.read('experiments', {'metadata.user': 'tsirif'})
+    experiment_dict = dict((experiment['name'], experiment) for experiment in experiments)
+    trials = db.read('trials')
+
+    for trial in trials:
+        query = {'experiment': trial['experiment']}
+        update = {'experiment': experiment_dict[trial['experiment']]['_id']}
+        db.write('trials', update, query)

--- a/tests/unittests/core/experiment.yaml
+++ b/tests/unittests/core/experiment.yaml
@@ -39,7 +39,7 @@
   max_trials: 1000
 
   # functional info
-  status: completed  # pending, done, broken
+  status: pending  # pending, done, broken
 
   # **complete** specification of algorithms used
   # user's configuration, but defaults are inferred
@@ -72,6 +72,35 @@
   pool_size: 2
   max_trials: 1000
   status: broken
+  algorithms:
+    dumbalgo:  # this must be logged as `Experiment` would log it, complete specification
+      value: 5
+      scoring: 0
+      judgement: ~
+      suspend: False
+      done: False
+
+- name: supernaedo4
+
+  metadata:
+    user: tsirif
+    datetime: 2017-11-22T21:00:00
+    orion_version: 0.1
+    user_script: full_path/ieeeela.py
+    user_args: ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])", "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"]
+    user_vcs: git
+    user_version: ~
+    user_commit_hash: as5f7asf5asfa7sf
+  refers:
+    name: supernaedo1
+    user: tsirif
+    params:
+      - name: decoding_layer
+        type: categorical
+        value: gru
+  pool_size: 2
+  max_trials: 1
+  status: done
   algorithms:
     dumbalgo:  # this must be logged as `Experiment` would log it, complete specification
       value: 5
@@ -246,6 +275,28 @@
     - name: /decoding_layer
       type: categorical
       value: lstm_with_attention
+
+- experiment: supernaedo4
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 2
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding_layer
+      type: categorical
+      value: rnn
+    - name: /decoding_layer
+      type: categorical
+      value: rnn
 ---
 
 # Example of entries in `workers` collection

--- a/tests/unittests/core/mongodb_test.py
+++ b/tests/unittests/core/mongodb_test.py
@@ -250,13 +250,13 @@ class TestRead(object):
             'trials',
             {'experiment': 'supernaedo2',
              'submit_time': {'$gte': datetime(2017, 11, 23, 0, 0, 0)}})
-        assert value == exp_config[1][2:]
+        assert value == exp_config[1][2:7]
 
         value = orion_db.read(
             'trials',
             {'experiment': 'supernaedo2',
              'submit_time': {'$gt': datetime(2017, 11, 23, 0, 0, 0)}})
-        assert value == exp_config[1][3:]
+        assert value == exp_config[1][3:7]
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -299,7 +299,8 @@ class TestWrite(object):
         value = list(database.experiments.find({}))
         assert value[0]['pool_size'] == 16
         assert value[1]['pool_size'] == 16
-        assert value[2]['pool_size'] == 2
+        assert value[2]['pool_size'] == 16
+        assert value[3]['pool_size'] == 2
 
     def test_update_with_id(self, exp_config, database, orion_db):
         """Query using ``_id`` key."""
@@ -344,8 +345,8 @@ class TestReadAndWrite(object):
             'experiments',
             {'name': 'supernaedo2', 'metadata.user': 'dendi'},
             {'status': 'lalala'})
-        exp_config[0][2]['status'] = 'lalala'
-        assert loaded_config == exp_config[0][2]
+        exp_config[0][3]['status'] = 'lalala'
+        assert loaded_config == exp_config[0][3]
 
     def test_read_and_write_many(self, database, orion_db, exp_config):
         """Should update only one entry."""
@@ -385,11 +386,12 @@ class TestRemove(object):
         """Should match existing entries, and delete them all."""
         filt = {'metadata.user': 'tsirif'}
         count_before = database.experiments.count()
+        count_filt = database.experiments.count(filt)
         # call interface
         assert orion_db.remove('experiments', filt) is True
-        assert database.experiments.count() == count_before - 2
+        assert database.experiments.count() == count_before - count_filt
         assert database.experiments.count() == 1
-        assert list(database.experiments.find()) == [exp_config[0][2]]
+        assert list(database.experiments.find()) == [exp_config[0][3]]
 
     def test_remove_with_id(self, exp_config, database, orion_db):
         """Query using ``_id`` key."""

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -593,23 +593,25 @@ class TestInitExperimentView(object):
 
     @pytest.mark.usefixtures("with_user_tsirif")
     def test_empty_experiment_view(self):
-        """Hit user name, but exp_name does not hit the db, create new entry."""
-        exp = ExperimentView('supernaekei')
-
-        assert exp._id is None
+        """Hit user name, but exp_name does not hit the db."""
+        with pytest.raises(ValueError) as exc_info:
+            ExperimentView('supernaekei')
+        assert ("No experiment with given name 'supernaekei' for user 'tsirif'"
+                in str(exc_info.value))
 
     @pytest.mark.usefixtures("with_user_bouthilx")
     def test_empty_experiment_view_due_to_username(self):
         """Hit exp_name, but user's name does not hit the db, create new entry."""
-        exp = ExperimentView('supernaekei')
-
-        assert exp._id is None
+        with pytest.raises(ValueError) as exc_info:
+            ExperimentView('supernaedo2')
+        assert ("No experiment with given name 'supernaedo2' for user 'bouthilx'"
+                in str(exc_info.value))
 
     @pytest.mark.usefixtures("with_user_tsirif")
     def test_existing_experiment_view(self, create_db_instance, exp_config):
         """Hit exp_name + user's name in the db, fetch most recent entry."""
         exp = ExperimentView('supernaedo2')
-        assert exp._experiment._init_done is False
+        assert exp._experiment._init_done is True
         assert exp._experiment._db._database is create_db_instance
         assert exp._id == exp_config[0][0]['_id']
         assert exp.name == exp_config[0][0]['name']

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -688,6 +688,10 @@ def test_view_is_done_property(hacked_exp):
     experiment_view = ExperimentView(hacked_exp.name)
     experiment_view._experiment = hacked_exp
 
+    # Fully configure wrapper experiment (should normally occur inside ExperimentView.__init__
+    # but hacked_exp has been _hacked_ inside afterwards.
+    hacked_exp.configure(hacked_exp.configuration)
+
     assert experiment_view.is_done is False
 
     with pytest.raises(AttributeError):

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -621,7 +621,7 @@ class TestInitExperimentView(object):
         assert exp.pool_size == exp_config[0][0]['pool_size']
         assert exp.max_trials == exp_config[0][0]['max_trials']
         assert exp.status == exp_config[0][0]['status']
-        assert exp.algorithms == exp_config[0][0]['algorithms']
+        assert exp.algorithms.configuration == exp_config[0][0]['algorithms']
 
         with pytest.raises(AttributeError):
             exp.this_is_not_in_config = 5

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -666,6 +666,22 @@ def test_view_is_done_property(hacked_exp):
     assert experiment_view.is_done is True
 
 
+def test_view_algo_is_done_property(hacked_exp):
+    """Check experiment's algo stopping conditions accessed from view."""
+    experiment_view = ExperimentView(hacked_exp.name)
+    experiment_view._experiment = hacked_exp
+
+    # Fully configure wrapper experiment (should normally occur inside ExperimentView.__init__
+    # but hacked_exp has been _hacked_ inside afterwards.
+    hacked_exp.configure(hacked_exp.configuration)
+
+    assert experiment_view.is_done is False
+
+    hacked_exp.algorithms.algorithm.done = True
+
+    assert experiment_view.is_done is True
+
+
 def test_experiment_view_stats(hacked_exp, exp_config, random_dt):
     """Check that property stats from view is consistent."""
     experiment_view = ExperimentView(hacked_exp.name)

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -448,7 +448,6 @@ class TestConfigProperty(object):
         new_config['algorithms'] = 'dumbalgo'
         exp = Experiment('supernaedo3')
         exp.configure(new_config)
-        new_config['status'] = 'pending'
         new_config['algorithms'] = dict()
         new_config['algorithms']['dumbalgo'] = dict()
         new_config['algorithms']['dumbalgo']['done'] = False
@@ -458,6 +457,39 @@ class TestConfigProperty(object):
         new_config['algorithms']['dumbalgo']['value'] = 5
         assert exp._id == new_config.pop('_id')
         assert exp.configuration == new_config
+
+    @pytest.mark.usefixtures("trial_id_substitution")
+    def test_status_is_pending_when_increase_max_trials(self, exp_config):
+        """Attribute exp.algorithms become objects after init."""
+        exp = Experiment('supernaedo4')
+
+        # Deliver an external configuration to finalize init
+        exp.configure(exp_config[0][2])
+
+        assert exp.status == "done"
+
+        exp = Experiment('supernaedo4')
+        # Deliver an external configuration to finalize init
+        exp_config[0][2]['max_trials'] = 1000
+        exp.configure(exp_config[0][2])
+
+        assert exp.status == "pending"
+
+    @pytest.mark.usefixtures("trial_id_substitution")
+    def test_status_stays_broken(self, exp_config):
+        """Attribute exp.algorithms become objects after init."""
+        exp = Experiment('supernaedo3')
+        # Deliver an external configuration to finalize init
+        exp.configure(exp_config[0][1])
+
+        assert exp.status == "broken"
+
+        exp = Experiment('supernaedo3')
+        # Deliver an external configuration to finalize init
+        exp_config[0][1]['max_trials'] = 1000
+        exp.configure(exp_config[0][1])
+
+        assert exp.status == "broken"
 
 
 class TestReserveTrial(object):
@@ -519,7 +551,7 @@ class TestReserveTrial(object):
     def test_reserve_with_score(self, hacked_exp, exp_config):
         """Reserve with a score object that can do its job."""
         self.times_called = 0
-        hacked_exp.configure(exp_config[0][2])
+        hacked_exp.configure(exp_config[0][3])
         trial = hacked_exp.reserve_trial(score_handle=self.fake_handle)
         exp_config[1][6]['status'] = 'reserved'
         assert trial.to_dict() == exp_config[1][6]
@@ -582,7 +614,7 @@ def test_experiment_stats(hacked_exp, exp_config, random_dt):
     assert stats['trials_completed'] == 3
     assert stats['best_trials_id'] == exp_config[1][1]['_id']
     assert stats['best_evaluation'] == 2
-    assert stats['start_time'] == exp_config[0][2]['metadata']['datetime']
+    assert stats['start_time'] == exp_config[0][3]['metadata']['datetime']
     assert stats['finish_time'] == exp_config[1][2]['end_time']
     assert stats['duration'] == stats['finish_time'] - stats['start_time']
     assert len(stats) == 6
@@ -691,7 +723,7 @@ def test_experiment_view_stats(hacked_exp, exp_config, random_dt):
     assert stats['trials_completed'] == 3
     assert stats['best_trials_id'] == exp_config[1][1]['_id']
     assert stats['best_evaluation'] == 2
-    assert stats['start_time'] == exp_config[0][2]['metadata']['datetime']
+    assert stats['start_time'] == exp_config[0][3]['metadata']['datetime']
     assert stats['finish_time'] == exp_config[1][2]['end_time']
     assert stats['duration'] == stats['finish_time'] - stats['start_time']
     assert len(stats) == 6

--- a/tests/unittests/core/test_producer.py
+++ b/tests/unittests/core/test_producer.py
@@ -10,7 +10,7 @@ from orion.core.worker.producer import Producer
 def producer(hacked_exp, random_dt, exp_config):
     """Return a setup `Producer`."""
     # make init done
-    hacked_exp.configure(exp_config[0][2])
+    hacked_exp.configure(exp_config[0][3])
     # insert fake point
     fake_point = ('lstm', 'gru')
     assert fake_point in hacked_exp.space


### PR DESCRIPTION
Why:

With experiment version control there is the possibility of having many
experiments instantiated at the same time but only one should be
editable, the _main_ one. All the others should not be able to make
modifications in the database. This commit is an attempt at reducing
write errors by wrapping the experiment with a read-only wrapper which
defines which attributes can be accessed and which not.

Note:

It will still be possible to access the write methods of the experiment,
by explicitly fetching it with by accessing the sub attribute of the
wrapper (ex: `experiment_view._experiment.register_trials()`).
Nonetheless the current wrapper makes it less likely to do so by error.

How:

Create an empty class with a `valid_attributes`. list which defines which
attribute and method may be accessed. The method `.__getattr__` filters out
the request on the wrapper based on `valid_attributes`.

The property `is_done` is slightly modified in the view since
`experiment.is_done` would normally do a write on the database. If
`wrapper.is_done` returns True, it will not update the database like the
normal experiment would.