### PR TITLE
Experiment nodes

### DIFF
--- a/src/orion/core/cli/__init__.py
+++ b/src/orion/core/cli/__init__.py
@@ -16,12 +16,6 @@ from orion.core.cli.base import OrionArgsParser
 
 log = logging.getLogger(__name__)
 
-CLI_DOC_HEADER = """
-orion:
-  Orion cli script for asynchronous distributed optimization
-
-"""
-
 
 def load_modules_parser(orion_parser):
     """Search through the `cli` folder for any module containing a `add_subparser` function"""
@@ -44,7 +38,7 @@ def main(argv=None):
     # Fetch experiment name, user's script path and command line arguments
     # Use `-h` option to show help
 
-    orion_parser = OrionArgsParser(CLI_DOC_HEADER)
+    orion_parser = OrionArgsParser()
 
     load_modules_parser(orion_parser)
 

--- a/src/orion/core/cli/__init__.py
+++ b/src/orion/core/cli/__init__.py
@@ -12,7 +12,7 @@
 import logging
 import os
 
-from orion.core.cli import resolve_config
+from orion.core.cli.base import OrionArgsParser
 
 log = logging.getLogger(__name__)
 
@@ -21,20 +21,6 @@ orion:
   Orion cli script for asynchronous distributed optimization
 
 """
-
-
-def main(argv=None):
-    """Entry point for `orion.core` functionality."""
-    # Fetch experiment name, user's script path and command line arguments
-    # Use `-h` option to show help
-
-    orion_parser = resolve_config.OrionArgsParser(CLI_DOC_HEADER)
-
-    load_modules_parser(orion_parser)
-
-    orion_parser.execute(argv)
-
-    return 0
 
 
 def load_modules_parser(orion_parser):
@@ -51,6 +37,20 @@ def load_modules_parser(orion_parser):
         if hasattr(module, 'add_subparser'):
             add_subparser = getattr(module, 'add_subparser')
             add_subparser(orion_parser.get_subparsers())
+
+
+def main(argv=None):
+    """Entry point for `orion.core` functionality."""
+    # Fetch experiment name, user's script path and command line arguments
+    # Use `-h` option to show help
+
+    orion_parser = OrionArgsParser(CLI_DOC_HEADER)
+
+    load_modules_parser(orion_parser)
+
+    orion_parser.execute(argv)
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.cli` -- Base class and function utilities for cli
+==================================================================
+
+.. module:: cli
+   :platform: Unix
+   :synopsis: Orion main parser class and helper functions to parse command-line options
+
+"""
+import argparse
+import logging
+import textwrap
+
+import orion
+
+
+class OrionArgsParser:
+    """Parser object handling the upper-level parsing of Oríon's arguments."""
+
+    def __init__(self, description):
+        """Create the pre-command arguments"""
+        self.description = description
+
+        self.parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=textwrap.dedent(description))
+
+        self.parser.add_argument(
+            '-V', '--version',
+            action='version', version='orion ' + orion.core.__version__)
+
+        self.parser.add_argument(
+            '-v', '--verbose',
+            action='count', default=0,
+            help="logging levels of information about the process (-v: INFO. -vv: DEBUG)")
+
+        self.subparsers = self.parser.add_subparsers(help='sub-command help')
+
+    def get_subparsers(self):
+        """Return the subparser object for this parser."""
+        return self.subparsers
+
+    def parse(self, argv):
+        """Call argparse and generate a dictionary of arguments' value"""
+        args = vars(self.parser.parse_args(argv))
+
+        verbose = args.pop('verbose', 0)
+        if verbose == 1:
+            logging.basicConfig(level=logging.INFO)
+        elif verbose == 2:
+            logging.basicConfig(level=logging.DEBUG)
+
+        function = args.pop('func')
+        return args, function
+
+    def execute(self, argv):
+        """Execute main function of the subparser"""
+        args, function = self.parse(argv)
+        function(args)
+
+
+def get_basic_args_group(parser):
+    """Return the basic arguments for any command."""
+    basic_args_group = parser.add_argument_group(
+        "Oríon arguments (optional)",
+        description="These arguments determine orion's behaviour")
+
+    basic_args_group.add_argument(
+        '-n', '--name',
+        type=str, metavar='stringID',
+        help="experiment's unique name; "
+             "(default: None - specified either here or in a config)")
+
+    basic_args_group.add_argument('-c', '--config', type=argparse.FileType('r'),
+                                  metavar='path-to-config', help="user provided "
+                                  "orion configuration file")
+
+    return basic_args_group
+
+
+def get_user_args_group(parser):
+    """
+    Return the user group arguments for any command.
+    User group arguments are composed of the user script and the user args
+    """
+    usergroup = parser.add_argument_group(
+        "User script related arguments",
+        description="These arguments determine user's script behaviour "
+                    "and they can serve as orion's parameter declaration.")
+
+    usergroup.add_argument(
+        'user_script', type=str, metavar='path-to-script',
+        help="your experiment's script")
+
+    usergroup.add_argument(
+        'user_args', nargs=argparse.REMAINDER, metavar='...',
+        help="Command line arguments to your script (if any). A configuration "
+             "file intended to be used with 'userscript' must be given as a path "
+             "in the **first positional** argument OR using `--config=<path>` "
+             "keyword argument.")
+
+    return usergroup

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -15,10 +15,17 @@ import textwrap
 import orion
 
 
+CLI_DOC_HEADER = """
+orion:
+  Orion cli script for asynchronous distributed optimization
+
+"""
+
+
 class OrionArgsParser:
     """Parser object handling the upper-level parsing of Oríon's arguments."""
 
-    def __init__(self, description):
+    def __init__(self, description=CLI_DOC_HEADER):
         """Create the pre-command arguments"""
         self.description = description
 

--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -14,7 +14,7 @@ import logging
 
 from orion.core.cli import base as cli
 from orion.core.io import resolve_config
-from orion.core.io.experiment_builder import ExperimentBuilder
+from orion.core.io.evc_builder import EVCBuilder
 from orion.core.worker import workon
 
 log = logging.getLogger(__name__)
@@ -45,5 +45,7 @@ def add_subparser(parser):
 
 def main(args):
     """Build experiment and execute hunt command"""
-    experiment = ExperimentBuilder().build_from(args)
+    args['root'] = None
+    args['leafs'] = []
+    experiment = EVCBuilder().build_from(args)
     workon(experiment)

--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -14,7 +14,8 @@ import logging
 import os
 
 import orion
-from orion.core.cli import resolve_config
+from orion.core.io import resolve_config
+from orion.core.cli import base as cli
 from orion.core.io.database import Database, DuplicateKeyError
 from orion.core.worker import workon
 from orion.core.worker.experiment import Experiment
@@ -26,7 +27,7 @@ def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
     hunt_parser = parser.add_parser('hunt', help='hunt help')
 
-    orion_group = resolve_config.get_basic_args_group(hunt_parser)
+    orion_group = cli.get_basic_args_group(hunt_parser)
 
     orion_group.add_argument(
         '--max-trials', type=int, metavar='#',
@@ -38,7 +39,7 @@ def add_subparser(parser):
         help="number of concurrent workers to evaluate candidate samples "
              "(default: %s)" % resolve_config.DEF_CMD_POOL_SIZE[1])
 
-    resolve_config.get_user_args_group(hunt_parser)
+    cli.get_user_args_group(hunt_parser)
 
     hunt_parser.set_defaults(func=main)
 

--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -11,9 +11,7 @@
 """
 
 import logging
-import os
 
-import orion
 from orion.core.cli import base as cli
 from orion.core.io import resolve_config
 from orion.core.io.experiment_builder import ExperimentBuilder
@@ -46,32 +44,6 @@ def add_subparser(parser):
 
 
 def main(args):
-    """Fetch config and execute hunt command"""
-    # Note: Side effects on args
-    set_metadata(args)
-
-    _execute(args)
-
-
-def set_metadata(args):
-    """Set metadata from command line arguments."""
-    # Explicitly add orion's version as experiment's metadata
-    args['metadata'] = dict()
-    args['metadata']['orion_version'] = orion.core.__version__
-    log.debug("Using orion version %s", args['metadata']['orion_version'])
-
-    # Move 'user_script' and 'user_args' to 'metadata' key
-    user_script = args.pop('user_script')
-    abs_user_script = os.path.abspath(user_script)
-    if resolve_config.is_exe(abs_user_script):
-        user_script = abs_user_script
-
-    args['metadata']['user_script'] = user_script
-    args['metadata']['user_args'] = args.pop('user_args')
-    log.debug("Problem definition: %s %s", args['metadata']['user_script'],
-              ' '.join(args['metadata']['user_args']))
-
-
-def _execute(cmdargs):
-    experiment = ExperimentBuilder().build_from(cmdargs)
+    """Build experiment and execute hunt command"""
+    experiment = ExperimentBuilder().build_from(args)
     workon(experiment)

--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -14,11 +14,10 @@ import logging
 import os
 
 import orion
-from orion.core.io import resolve_config
 from orion.core.cli import base as cli
-from orion.core.io.database import Database, DuplicateKeyError
+from orion.core.io import resolve_config
+from orion.core.io.experiment_builder import ExperimentBuilder
 from orion.core.worker import workon
-from orion.core.worker.experiment import Experiment
 
 log = logging.getLogger(__name__)
 
@@ -49,19 +48,17 @@ def add_subparser(parser):
 def main(args):
     """Fetch config and execute hunt command"""
     # Note: Side effects on args
-    config = fetch_config(args)
+    set_metadata(args)
 
-    _execute(args, config)
+    _execute(args)
 
 
-def fetch_config(args):
-    """Get options from command line arguments."""
+def set_metadata(args):
+    """Set metadata from command line arguments."""
     # Explicitly add orion's version as experiment's metadata
     args['metadata'] = dict()
     args['metadata']['orion_version'] = orion.core.__version__
     log.debug("Using orion version %s", args['metadata']['orion_version'])
-
-    config = resolve_config.fetch_config(args)
 
     # Move 'user_script' and 'user_args' to 'metadata' key
     user_script = args.pop('user_script')
@@ -74,105 +71,7 @@ def fetch_config(args):
     log.debug("Problem definition: %s %s", args['metadata']['user_script'],
               ' '.join(args['metadata']['user_args']))
 
-    return config
 
-
-def _execute(cmdargs, cmdconfig):
-    experiment = _infer_experiment(cmdargs, cmdconfig)
+def _execute(cmdargs):
+    experiment = ExperimentBuilder().build_from(cmdargs)
     workon(experiment)
-
-
-def _infer_experiment(cmdargs, cmdconfig):
-    # Initialize configuration dictionary.
-    # Fetch info from defaults and configurations from default locations.
-    expconfig = resolve_config.fetch_default_options()
-
-    # Fetch orion system variables (database and resource information)
-    # See :const:`orion.core.io.resolve_config.ENV_VARS` for environmental
-    # variables used
-    expconfig = resolve_config.merge_env_vars(expconfig)
-
-    # Initialize singleton database object
-    tmpconfig = resolve_config.merge_orion_config(expconfig, dict(),
-                                                  cmdconfig, cmdargs)
-
-    db_opts = tmpconfig['database']
-    dbtype = db_opts.pop('type')
-
-    log.debug("Creating %s database client with args: %s", dbtype, db_opts)
-    Database(of_type=dbtype, **db_opts)
-
-    # Information should be enough to infer experiment's name.
-    exp_name = tmpconfig['name']
-    if exp_name is None:
-        raise RuntimeError("Could not infer experiment's name. "
-                           "Please use either `name` cmd line arg or provide "
-                           "one in orion's configuration file.")
-
-    experiment = create_experiment(exp_name, expconfig, cmdconfig, cmdargs)
-
-    return experiment
-
-
-def create_experiment(exp_name, expconfig, cmdconfig, cmdargs):
-    """Create an experiment based on configuration.
-
-    Configuration is a combination of command line, experiment configuration
-    file, experiment configuration in database and orion configuration files.
-
-    Precedence of configurations is:
-    `cmdargs` > `cmdconfig` > `dbconfig` > `expconfig`
-
-    This means `expconfig` values would be overwritten by `dbconfig` and so on.
-
-    Parameters
-    ----------
-    exp_name: str
-        Name of the experiment
-    expconfig: dict
-        Configuration coming from default configuration files.
-    cmdconfig: dict
-        Configuration coming from configuration file.
-    cmdargs: dict
-        Configuration coming from command line arguments.
-
-    """
-    # Initialize experiment object.
-    # Check for existing name and fetch configuration.
-    experiment = Experiment(exp_name)
-    dbconfig = experiment.configuration
-
-    log.debug("DB config")
-    log.debug(dbconfig)
-
-    expconfig = resolve_config.merge_orion_config(expconfig, dbconfig,
-                                                  cmdconfig, cmdargs)
-    # Infer rest information about the process + versioning
-    expconfig['metadata'] = infer_versioning_metadata(expconfig['metadata'])
-
-    # Pop out configuration concerning databases and resources
-    expconfig.pop('database', None)
-    expconfig.pop('resources', None)
-
-    log.info(expconfig)
-
-    # Finish experiment's configuration and write it to database.
-    try:
-        experiment.configure(expconfig)
-    except DuplicateKeyError:
-        # Fails if concurrent experiment with identical (name, metadata.user)
-        # is written first in the database.
-        # Next infer_experiment() should either load experiment from database
-        # and run smoothly if identical or trigger an experiment fork.
-        # In other words, there should not be more than 1 level of recursion.
-        experiment = create_experiment(exp_name, expconfig, cmdconfig, cmdargs)
-
-    return experiment
-
-
-def infer_versioning_metadata(existing_metadata):
-    """Infer information about user's script versioning if available."""
-    # VCS system
-    # User repo's version
-    # User repo's HEAD commit hash
-    return existing_metadata

--- a/src/orion/core/cli/init_only.py
+++ b/src/orion/core/cli/init_only.py
@@ -11,7 +11,6 @@
 
 import logging
 
-import orion
 from orion.core.cli import base as cli
 from orion.core.io.experiment_builder import ExperimentBuilder
 
@@ -32,23 +31,6 @@ def add_subparser(parser):
 
 
 def main(args):
-    """Set metadata and initialize experiment"""
-    set_metadata(args)
-
-    _execute(args)
-
-
-def set_metadata(args):
-    """Set metadata from command line arguments."""
-    # Explicitly add orion's version as experiment's metadata
-    args['metadata'] = dict()
-    args['metadata']['orion_version'] = orion.core.__version__
-    log.debug("Using orion version %s", args['metadata']['orion_version'])
-
-    args.pop('user_script')
-    args['metadata']['user_args'] = args.pop('user_args')
-
-
-# By building the experiment, we create a new experiment document in database
-def _execute(cmdargs):
-    ExperimentBuilder().build_from(cmdargs)
+    """Build and initialize experiment"""
+    # By building the experiment, we create a new experiment document in database
+    ExperimentBuilder().build_from(args)

--- a/src/orion/core/cli/init_only.py
+++ b/src/orion/core/cli/init_only.py
@@ -12,10 +12,8 @@
 import logging
 
 import orion
-from orion.core.io import resolve_config
 from orion.core.cli import base as cli
-from orion.core.io.database import Database, DuplicateKeyError
-from orion.core.worker.experiment import Experiment
+from orion.core.io.experiment_builder import ExperimentBuilder
 
 log = logging.getLogger(__name__)
 
@@ -34,119 +32,23 @@ def add_subparser(parser):
 
 
 def main(args):
-    """Fetch config and initialize experiment"""
-    # Note: Side effects on args
-    config = fetch_config(args)
+    """Set metadata and initialize experiment"""
+    set_metadata(args)
 
-    _execute(args, config)
+    _execute(args)
 
 
-def fetch_config(args):
-    """Create the dictionary of modified args for the execution of the command"""
+def set_metadata(args):
+    """Set metadata from command line arguments."""
     # Explicitly add orion's version as experiment's metadata
     args['metadata'] = dict()
     args['metadata']['orion_version'] = orion.core.__version__
     log.debug("Using orion version %s", args['metadata']['orion_version'])
 
-    config = resolve_config.fetch_config(args)
-
     args.pop('user_script')
     args['metadata']['user_args'] = args.pop('user_args')
 
-    return config
 
-
-# By inferring the experiment, we create a new configured experiment
-def _execute(cmdargs, cmdconfig):
-    _infer_experiment(cmdargs, cmdconfig)
-
-
-def _infer_experiment(cmdargs, cmdconfig):
-    # Initialize configuration dictionary.
-    # Fetch info from defaults and configurations from default locations.
-    expconfig = resolve_config.fetch_default_options()
-
-    # Fetch orion system variables (database and resource information)
-    # See :const:`orion.core.io.resolve_config.ENV_VARS` for environmental
-    # variables used
-    expconfig = resolve_config.merge_env_vars(expconfig)
-
-    # Initialize singleton database object
-    tmpconfig = resolve_config.merge_orion_config(expconfig, dict(),
-                                                  cmdconfig, cmdargs)
-    db_opts = tmpconfig['database']
-    dbtype = db_opts.pop('type')
-
-    log.debug("Creating %s database client with args: %s", dbtype, db_opts)
-    Database(of_type=dbtype, **db_opts)
-
-    # Information should be enough to infer experiment's name.
-    exp_name = tmpconfig['name']
-    if exp_name is None:
-        raise RuntimeError("Could not infer experiment's name. "
-                           "Please use either `name` cmd line arg or provide "
-                           "one in orion's configuration file.")
-
-    experiment = create_experiment(exp_name, expconfig, cmdconfig, cmdargs)
-
-    return experiment
-
-
-def create_experiment(exp_name, expconfig, cmdconfig, cmdargs):
-    """Create an experiment based on configuration.
-
-    Configuration is a combination of command line, experiment configuration
-    file, experiment configuration in database and orion configuration files.
-
-    Precedence of configurations is:
-    `cmdargs` > `cmdconfig` > `dbconfig` > `expconfig`
-
-    This means `expconfig` values would be overwritten by `dbconfig` and so on.
-
-    Parameters
-    ----------
-    exp_name: str
-        Name of the experiment
-    expconfig: dict
-        Configuration coming from default configuration files.
-    cmdconfig: dict
-        Configuration coming from configuration file.
-    cmdargs: dict
-        Configuration coming from command line arguments.
-
-    """
-    # Initialize experiment object.
-    # Check for existing name and fetch configuration.
-    experiment = Experiment(exp_name)
-    dbconfig = experiment.configuration
-
-    expconfig = resolve_config.merge_orion_config(expconfig, dbconfig,
-                                                  cmdconfig, cmdargs)
-
-    # Infer rest information about the process + versioning
-    expconfig['metadata'] = infer_versioning_metadata(expconfig['metadata'])
-
-    # Pop out configuration concerning databases and resources
-    expconfig.pop('database', None)
-    expconfig.pop('resources', None)
-
-    # Finish experiment's configuration and write it to database.
-    try:
-        experiment.configure(expconfig)
-    except DuplicateKeyError:
-        # Fails if concurrent experiment with identical (name, metadata.user)
-        # is written first in the database.
-        # Next infer_experiment() should either load experiment from database
-        # and run smoothly if identical or trigger an experiment fork.
-        # In other words, there should not be more than 1 level of recursion.
-        experiment = create_experiment(exp_name, expconfig, cmdconfig, cmdargs)
-
-    return experiment
-
-
-def infer_versioning_metadata(existing_metadata):
-    """Infer information about user's script versioning if available."""
-    # VCS system
-    # User repo's version
-    # User repo's HEAD commit hash
-    return existing_metadata
+# By building the experiment, we create a new experiment document in database
+def _execute(cmdargs):
+    ExperimentBuilder().build_from(cmdargs)

--- a/src/orion/core/cli/init_only.py
+++ b/src/orion/core/cli/init_only.py
@@ -12,7 +12,8 @@
 import logging
 
 import orion
-from orion.core.cli import resolve_config
+from orion.core.io import resolve_config
+from orion.core.cli import base as cli
 from orion.core.io.database import Database, DuplicateKeyError
 from orion.core.worker.experiment import Experiment
 
@@ -23,9 +24,9 @@ def add_subparser(parser):
     """Return the parser that needs to be used for this command"""
     init_only_parser = parser.add_parser('init_only', help='init_only help')
 
-    resolve_config.get_basic_args_group(init_only_parser)
+    cli.get_basic_args_group(init_only_parser)
 
-    resolve_config.get_user_args_group(init_only_parser)
+    cli.get_user_args_group(init_only_parser)
 
     init_only_parser.set_defaults(func=main)
 

--- a/src/orion/core/cli/insert.py
+++ b/src/orion/core/cli/insert.py
@@ -16,7 +16,8 @@ import os
 import re
 
 import orion
-from orion.core.cli import resolve_config
+from orion.core.io import resolve_config
+from orion.core.cli import base as cli
 from orion.core.io.convert import infer_converter_from_file_type
 from orion.core.io.database import Database
 from orion.core.io.space_builder import SpaceBuilder
@@ -30,9 +31,9 @@ def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
     insert_parser = parser.add_parser('insert', help='insert help')
 
-    resolve_config.get_basic_args_group(insert_parser)
+    cli.get_basic_args_group(insert_parser)
 
-    resolve_config.get_user_args_group(insert_parser)
+    cli.get_user_args_group(insert_parser)
 
     insert_parser.set_defaults(func=main)
 

--- a/src/orion/core/cli/insert.py
+++ b/src/orion/core/cli/insert.py
@@ -16,13 +16,10 @@ import os
 import re
 
 import orion
-from orion.core.io import resolve_config
 from orion.core.cli import base as cli
 from orion.core.io.convert import infer_converter_from_file_type
-from orion.core.io.database import Database
-from orion.core.io.space_builder import SpaceBuilder
+from orion.core.io.experiment_builder import ExperimentBuilder
 from orion.core.utils.format_trials import tuple_to_trial
-from orion.core.worker.experiment import Experiment
 
 log = logging.getLogger(__name__)
 
@@ -42,43 +39,34 @@ def add_subparser(parser):
 
 def main(args):
     """Fetch config and insert new point"""
-    # Note: Side effects on args
-    config = fetch_config(args)
+    set_metadata(args)
 
-    _execute(args, config)
+    _execute(args)
 
 
-def fetch_config(args):
-    """Get options from command line arguments."""
+def set_metadata(args):
+    """Set metadata from command line arguments."""
     # Explicitly add orion's version as experiment's metadata
     args['metadata'] = dict()
     args['metadata']['orion_version'] = orion.core.__version__
     log.debug("Using orion version %s", args['metadata']['orion_version'])
 
-    config = resolve_config.fetch_config(args)
-
     args.pop('user_script')
     args['metadata']['user_args'] = args.pop('user_args')
 
-    return config
 
-
-def _execute(cmd_args, file_config):
+def _execute(cmd_args):
     command_line_user_args = cmd_args['metadata'].pop('user_args', None)
-    experiment = _infer_experiment(cmd_args, file_config)
-
-    if experiment.id is None:
-        raise ValueError("No experiment with given name '%s' for user '%s' inside database, "
-                         "can't insert." % (experiment.name, experiment.metadata['user']))
+    experiment_view = ExperimentBuilder().build_view_from(cmd_args)
 
     transformed_args = _build_from(command_line_user_args)
-    exp_space = SpaceBuilder().build_from(experiment.configuration['metadata']['user_args'])
+    exp_space = experiment_view.space
 
     values = _create_tuple_from_values(transformed_args, exp_space)
 
     trial = tuple_to_trial(values, exp_space)
 
-    experiment.register_trials([trial])
+    ExperimentBuilder().build_from_config(experiment_view.configuration).register_trials([trial])
 
 
 def _validate_dimensions(transformed_args, exp_space):
@@ -133,91 +121,6 @@ def _create_tuple_from_values(transformed_args, exp_space):
             values.append(exp_space[namespace].default_value)
 
     return values
-
-
-def _infer_experiment(cmd_args, file_config):
-    # Initialize configuration dictionary.
-    # Fetch info from defaults and configurations from default locations.
-    expconfig = resolve_config.fetch_default_options()
-
-    # Fetch orion system variables (database and resource information)
-    # See :const:`orion.core.io.resolve_config.ENV_VARS` for environmental
-    # variables used
-    expconfig = resolve_config.merge_env_vars(expconfig)
-
-    # Initialize singleton database object
-    tmpconfig = resolve_config.merge_orion_config(expconfig, dict(),
-                                                  file_config, cmd_args)
-
-    db_opts = tmpconfig['database']
-    dbtype = db_opts.pop('type')
-
-    log.debug("Creating %s database client with args: %s", dbtype, db_opts)
-    Database(of_type=dbtype, **db_opts)
-
-    # Information should be enough to infer experiment's name.
-    exp_name = tmpconfig['name']
-    if exp_name is None:
-        raise RuntimeError("Could not infer experiment's name. "
-                           "Please use either `name` cmd line arg or provide "
-                           "one in orion's configuration file.")
-
-    experiment = create_experiment(exp_name, expconfig, file_config, cmd_args)
-
-    return experiment
-
-
-def create_experiment(exp_name, expconfig, file_config, cmd_args):
-    """Create an experiment based on configuration.
-
-    Configuration is a combination of command line, experiment configuration
-    file, experiment configuration in database and orion configuration files.
-
-    Precedence of configurations is:
-    `cmdargs` > `cmdconfig` > `dbconfig` > `expconfig`
-
-    This means `expconfig` values would be overwritten by `dbconfig` and so on.
-
-    Parameters
-    ----------
-    exp_name: str
-        Name of the experiment
-    expconfig: dict
-        Configuration coming from default configuration files.
-    cmdconfig: dict
-        Configuration coming from configuration file.
-    cmdargs: dict
-        Configuration coming from command line arguments.
-
-    """
-    # Initialize experiment object.
-    # Check for existing name and fetch configuration.
-    experiment = Experiment(exp_name)
-    dbconfig = experiment.configuration
-
-    log.debug("DB config")
-    log.debug(dbconfig)
-
-    expconfig = resolve_config.merge_orion_config(expconfig, dbconfig,
-                                                  file_config, cmd_args)
-    # Infer rest information about the process + versioning
-    expconfig['metadata'] = infer_versioning_metadata(expconfig['metadata'])
-
-    # Pop out configuration concerning databases and resources
-    expconfig.pop('database', None)
-    expconfig.pop('resources', None)
-
-    log.info(expconfig)
-
-    return experiment
-
-
-def infer_versioning_metadata(existing_metadata):
-    """Infer information about user's script versioning if available."""
-    # VCS system
-    # User repo's version
-    # User repo's HEAD commit hash
-    return existing_metadata
 
 
 def _build_from(cmd_args):

--- a/src/orion/core/cli/insert.py
+++ b/src/orion/core/cli/insert.py
@@ -15,7 +15,6 @@ import logging
 import os
 import re
 
-import orion
 from orion.core.cli import base as cli
 from orion.core.io.convert import infer_converter_from_file_type
 from orion.core.io.experiment_builder import ExperimentBuilder
@@ -39,25 +38,8 @@ def add_subparser(parser):
 
 def main(args):
     """Fetch config and insert new point"""
-    set_metadata(args)
-
-    _execute(args)
-
-
-def set_metadata(args):
-    """Set metadata from command line arguments."""
-    # Explicitly add orion's version as experiment's metadata
-    args['metadata'] = dict()
-    args['metadata']['orion_version'] = orion.core.__version__
-    log.debug("Using orion version %s", args['metadata']['orion_version'])
-
-    args.pop('user_script')
-    args['metadata']['user_args'] = args.pop('user_args')
-
-
-def _execute(cmd_args):
-    command_line_user_args = cmd_args['metadata'].pop('user_args', None)
-    experiment_view = ExperimentBuilder().build_view_from(cmd_args)
+    command_line_user_args = args.pop('user_args', None)
+    experiment_view = ExperimentBuilder().build_view_from(args)
 
     transformed_args = _build_from(command_line_user_args)
     exp_space = experiment_view.space

--- a/src/orion/core/evc/__init__.py
+++ b/src/orion/core/evc/__init__.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.evc` -- Experiment Version Control System
+==========================================================
+
+.. module:: evc
+   :platform: Unix
+   :synopsis: Organize related experiments inside a tree-structure using adapters to maintain
+      compatibility between them.
+"""

--- a/src/orion/core/evc/adapters.py
+++ b/src/orion/core/evc/adapters.py
@@ -1,0 +1,694 @@
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.evc.adapters` -- Adapters to connect experiments within the EVC system
+=======================================================================================
+
+.. module:: adapters
+   :platform: Unix
+   :synopsis: Adapters to connect experiments within the EVC system
+
+Experiment branches because of changes in the configuration or the user's code. This make
+experiments incompatible with one another unless we define adapters such that a branched experiment
+B can access trials from parent experiment A.
+
+Adapters have two main methods, forward and backward. The method forward defines how trials from
+parent experiment A are filtered or adapted to be compatible with experiment B. Modifications are
+only applied at execution time and are not saved anywhere in the database. Adapters only provides a
+view on an experiment.
+
+There is adapters for
+
+    * Dimension addition
+    * Dimension deletion
+    * Dimension renaming
+    * Change of dimension prior
+    * Change of algorithm
+    * Change of code
+    * Combining different adapters
+
+Adapters all have a `to_dict` method which provides sufficient information to rebuild the adapter.
+This is to facilitate save of adapters in a database and retrieval.
+
+Adapters can be build using the factory class `Adapter(**kwargs)` or using
+`Adapter.build(list_of_dicts)`.
+
+"""
+from abc import (ABCMeta, abstractmethod)
+import copy
+
+from orion.core.io.space_builder import DimensionBuilder
+from orion.core.utils import Factory
+from orion.core.worker.trial import Trial
+
+
+class BaseAdapter(object, metaclass=ABCMeta):
+    """Base class describing what an adapter can do."""
+
+    @abstractmethod
+    def forward(self, trials):
+        """Adapt trials of the parent experiment such that they are compatible to the child
+        experiment
+
+        Parameters
+        ----------
+        trials: list of :class:`orion.core.worker.trial.Trial`
+            List of :class:`orion.core.worker.trial.Trial` coming from the parent experiment
+
+        """
+        pass
+
+    @abstractmethod
+    def backward(self, trials):
+        """Adapt trials of the child experiment such that they are compatible to the parent
+        experiment
+
+        Parameters
+        ----------
+        trials: list of :class:`orion.core.worker.trial.Trial`
+            List of :class:`orion.core.worker.trial.Trial` coming from the child experiment
+
+        """
+        pass
+
+    @abstractmethod
+    def to_dict(self):
+        """Provide the configuration of the adapter as a dictionary
+
+        This method is intended for single adapters only.
+        For coherence, method configuration is used by all adapters, which is a list of dictionary
+        configurations.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.adapters.BaseAdapter.configuration`
+        """
+        pass
+
+    @property
+    def configuration(self):
+        """Provide the configuration of the adapter.
+
+        For simplicity, the configuration is always returned as if the adapter is a
+        CompositeAdapter, therefore no matter if the adapter is composite or not it will return a
+        list of configurations.
+
+        The dictionaries of the list can be used to recreate adapters, for any adapter class.
+
+        Examples
+        --------
+        .. code-block:: python
+           :linenos:
+
+            configuration = a_dummy_adapter.configuration[0]
+            another_dummy_adapter = Adapter.build([configuration])
+            assert another_dummy_adapter.configuration[0] == configuration
+
+        Returns
+        -------
+        dict
+            Configuration as a dictionary
+
+        """
+        return [self.to_dict()]
+
+
+class CompositeAdapter(BaseAdapter):
+    """Adapter which group many other adapters needed to connect two experiments
+
+    Attributes
+    ----------
+    adapters: instances of `orion.core.evc.adapters.BaseAdapter`
+        List of adaptors which are applied sequentially
+
+    """
+
+    def __init__(self, *adapters):
+        """Initialize with adapters
+
+        Parameters
+        ----------
+        adapters: instances of `orion.core.evc.adapters.BaseAdapter`
+            List of adaptors which are applied sequentially
+
+        """
+        if any(not isinstance(adapter, BaseAdapter) for adapter in adapters):
+            wrong_object_type = [type(adapter) for adapter in adapters
+                                 if not isinstance(adapter, BaseAdapter)][0]
+            raise TypeError("Provided adapters must be adapter objects, not '%s'" %
+                            str(wrong_object_type))
+
+        self.adapters = adapters
+
+    def forward(self, trials):
+        """Apply the adaptors on the parent's trials
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        for adapter in self.adapters:
+            trials = adapter.forward(trials)
+
+        return trials
+
+    def backward(self, trials):
+        """Apply the adaptors backward and in reverse order on the parent's trials
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.backward`
+        """
+        for adapter in self.adapters[::-1]:
+            trials = adapter.backward(trials)
+
+        return trials
+
+    def to_dict(self):
+        """Return nothing since it is not valid for CompositeAdapter
+
+        .. seealso::
+
+            :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
+            :meth:`orion.core.evc.adapters.CompositeAdapter.configuration`
+        """
+        pass
+
+    @property
+    def configuration(self):
+        """Provide the configuration of the adapter.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.configuration`
+        """
+        return [adapter.to_dict() for adapter in self.adapters]
+
+
+def apply_if_valid(name, trial, callback=None, raise_if_not=True):
+    """Detect a parameter in trial and call a callback on it if provided
+
+    Parameters
+    ----------
+    name: str
+        Name of the param to look for
+    trial: `orion.core.worker.trial.Trial`
+        Instance of trial to investigate
+    callback: None of callable
+        Function to call with (trial, param) with a parameter is found.
+        Defaults to None
+    raise_if_not: bool
+        raises RuntimeError if no parameter is found.
+        Defaults to True.
+
+    Returns
+    -------
+    bool
+        False if parameter is not found and `raise_if_not is False`.
+        True if parameter is found and callback is None.
+        Else, output of callback(trial, item).
+
+    """
+    for param in trial.params:
+        if param.name == name:
+            return callback is None or callback(trial, param)
+
+    if raise_if_not:
+        raise RuntimeError("Provided trial does not have a compatible configuration. "
+                           "A dimension named '%s' should be present.\n %s" %
+                           (name, trial))
+
+    return False
+
+
+class DimensionAddition(BaseAdapter):
+    """Adapter which adds a new dimension to parent's trials
+
+    This adaptation is based on the assumption that the trials of the parent experiment
+    are equivalent if we add the new dimension for a given default value.
+
+    On forward, the adapter add a dimension with provided default value to each trials.
+    On backward, the adapter filters trials and only keep with with the default value.
+
+    Attributes
+    ----------
+    param: instances of `orion.core.worker.trial.Trial.Param`
+        A parameter object which defines the name and default value of the name dimension.
+
+    """
+
+    def __init__(self, param):
+        """Initialize and instantiate the param if necessary
+
+        Parameters
+        ----------
+        param: instance of `orion.core.worker.trial.Trial.Param` or `dict`
+            A parameter object which defines the name and default value of the name dimension.
+            It can be either a dictionary definition or an instance of Param. If the former, then
+            a parameter is instantiated from the dictionary.
+
+        """
+        if isinstance(param, dict):
+            param = Trial.Param(**param)
+        elif not isinstance(param, Trial.Param):
+            raise TypeError("Invalid param argument type ('%s'). "
+                            "Param argument must be a Param object or a dictionnary "
+                            "as defined by Trial.Param.to_dict()." %
+                            str(type(param)))
+
+        self.param = param
+
+    def forward(self, trials):
+        """Add a dimension with provided default value to each trials of the parent
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        adapted_trials = []
+
+        for trial in trials:
+            if apply_if_valid(self.param.name, trial, raise_if_not=False):
+                raise RuntimeError("Provided trial does not have a compatible configuration. "
+                                   "A dimension named '%s' was already present.\n %s" %
+                                   (self.param.name, trial))
+
+            adapted_trial = copy.deepcopy(trial)
+            adapted_trial.params.append(self.param)
+            adapted_trials.append(adapted_trial)
+
+        return adapted_trials
+
+    def backward(self, trials):
+        """Filter out trials which have values different than the default one.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.backward`
+        """
+        adapted_trials = []
+
+        def remove_dimension(trial, param):
+            """Remove the param and keep the trial if param has default value"""
+            if param == self.param:
+                adapted_trial = copy.deepcopy(trial)
+                del adapted_trial.params[adapted_trial.params.index(self.param)]
+                adapted_trials.append(adapted_trial)
+                return True
+
+            return False
+
+        for trial in trials:
+            apply_if_valid(self.param.name, trial, remove_dimension, raise_if_not=True)
+
+        return adapted_trials
+
+    def to_dict(self):
+        """Provide the configuration of the adapter as a dictionary
+
+        .. seealso::
+
+            :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
+        """
+        ret = dict(
+            of_type=self.__class__.__name__.lower(),
+            param=self.param.to_dict())
+        return ret
+
+
+class DimensionDeletion(BaseAdapter):
+    """Adapter which remove a dimension to parent's trials
+
+    .. note::
+
+        This adapter is the opposite of `orion.core.evc.adapters.DimensionAddition`.
+
+    This adaptation is based on the assumption that the trials of the children experiment
+    are equivalent if we remove the new dimension for a given default value.
+
+    On forward, the adapter filters trials and only keep with with the default value.
+    On backward, the adapter add a dimension with provided default value to each trials.
+
+    Attributes
+    ----------
+    dimension_addition_adapter: instance of `orion.core.evc.adapters.DimensionAddition`
+        An adapter to add a new dimension, it is used by DimensionDeletion inversely to remove
+        a dimension.
+
+    """
+
+    def __init__(self, param):
+        """Initialize and instantiate the param if necessary
+
+        Parameters
+        ----------
+        param: instance of `orion.core.worker.trial.Trial.Param` or `dict`
+            A parameter object which defines the name and default value of the name dimension.
+            It can be either a dictionary definition or an instance of Param. If the former, then
+            a parameter is instantiated from the dictionary.
+
+        """
+        self.dimension_addition_adapter = DimensionAddition(param)
+
+    @property
+    def param(self):
+        """Parameter containing name and default value"""
+        return self.dimension_addition_adapter.param
+
+    def forward(self, trials):
+        """Filter out trials which have values different than the default one.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.DimensionAddition.backward`
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        return self.dimension_addition_adapter.backward(trials)
+
+    def backward(self, trials):
+        """Add a dimension with provided default value to each trials of the child.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.DimensionAddition.forward`
+            :meth:`orion.core.evc.BaseAdapter.backward`
+        """
+        return self.dimension_addition_adapter.forward(trials)
+
+    def to_dict(self):
+        """Provide the configuration of the adapter as a dictionary
+
+        .. seealso::
+
+            :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
+        """
+        ret = self.dimension_addition_adapter.to_dict()
+        ret['of_type'] = 'dimensiondeletion'
+        return ret
+
+
+class DimensionPriorChange(BaseAdapter):
+    """Adapter which filters parent's trials based on a new prior
+
+    On forward, the adapter filters out trials based on the child's prior.
+    On backward, the adapter filters out trials based on the parent's prior.
+
+    Attributes
+    ----------
+    name: `str`
+        Name of the dimension.
+    old_prior: `str`
+        string definition as parsable by `orion.core.io.space_builder`.
+    new_prior: `str`
+        string definition as parsable by `orion.core.io.space_builder`.
+    old_dimension: instance of `orion.algo.space.Dimension`
+        The dimension of the parent experiment
+    new_dimension: instance of `orion.algo.space.Dimension`
+        The dimension of the child experiment
+
+    """
+
+    def __init__(self, name, old_prior, new_prior):
+        """Initialize and instantiate dimensions
+
+        Parameters
+        ----------
+        name: `str`
+            Name of the dimension.
+        old_prior: `str`
+            string definition as parsable by `orion.core.io.space_builder`.
+        new_prior: `str`
+            string definition as parsable by `orion.core.io.space_builder`.
+
+        """
+        self.name = name
+        self.old_prior = old_prior
+        self.new_prior = new_prior
+        self.old_dimension = DimensionBuilder().build('old', old_prior)
+        self.new_dimension = DimensionBuilder().build('new', new_prior)
+
+        if self.old_dimension.shape != self.new_dimension.shape:
+            raise NotImplementedError("Oríon does not support yet adaptations on prior "
+                                      "shape changes.")
+
+    def forward(self, trials):
+        """Filter out trials which have out of bound values based on the child's prior.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        # pylint: disable=unused-argument
+        def is_in_bound(trial, param):
+            """Test if param's value is in the new prior's bounds"""
+            return param.value in self.new_dimension
+
+        return [trial for trial in trials if apply_if_valid(self.name, trial, callback=is_in_bound)]
+
+    def backward(self, trials):
+        """Filter out trials which have out of bound values based on the parent's prior.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.backward`
+        """
+        return DimensionPriorChange(self.name, self.new_prior, self.old_prior).forward(trials)
+
+    def to_dict(self):
+        """Provide the configuration of the adapter as a dictionary
+
+        .. seealso::
+
+            :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
+        """
+        ret = dict(
+            of_type=self.__class__.__name__.lower(),
+            name=self.name,
+            old_prior=self.old_prior,
+            new_prior=self.new_prior)
+        return ret
+
+
+class DimensionRenaming(BaseAdapter):
+    """Adapter which change the name of a dimension in parent's trials
+
+    On forward, the adapter change dimensions name from A to B.
+    On backward, the adapter change dimensions name from B to A.
+
+    Attributes
+    ----------
+    old_name: `str`
+        Name of the parent's dimension.
+    new_name: `str`
+        Name of the child's dimension.
+
+    """
+
+    def __init__(self, old_name, new_name):
+        """Initialize
+
+        Parameters
+        ----------
+        old_name: `str`
+            Name of the parent's dimension.
+        new_name: `str`
+            Name of the child's dimension.
+
+        """
+        if any(not isinstance(name, str) for name in [old_name, new_name]):
+            wrong_object_type = [type(name) for name in [old_name, new_name]
+                                 if not isinstance(name, str)][0]
+            raise TypeError("Invalid name type '%s'. Names must be strings." %
+                            str(wrong_object_type))
+        self.old_name = old_name
+        self.new_name = new_name
+
+    def forward(self, trials):
+        """Change name of dimension `old_name` to `new_name`.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        # pylint: disable=unused-argument
+        def rename(trial, param):
+            """Rename param to given new name"""
+            param.name = self.new_name
+            return True
+
+        adapted_trials = copy.deepcopy(trials)
+
+        for trial in adapted_trials:
+            apply_if_valid(self.old_name, trial, callback=rename, raise_if_not=True)
+
+        return adapted_trials
+
+    def backward(self, trials):
+        """Change name of dimension `new_name` to `old_name`.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        return DimensionRenaming(self.new_name, self.old_name).forward(trials)
+
+    def to_dict(self):
+        """Provide the configuration of the adapter as a dictionary
+
+        .. seealso::
+
+            :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
+        """
+        ret = dict(
+            of_type=self.__class__.__name__.lower(),
+            old_name=self.old_name,
+            new_name=self.new_name)
+        return ret
+
+
+class AlgorithmChange(BaseAdapter):
+    """Adapter for changes in algorithm definition
+
+    .. note::
+
+        Current implementation does nothing
+
+    """
+
+    def forward(self, trials):
+        """Pass all trials from parent experiment to child experiment
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        return trials
+
+    def backward(self, trials):
+        """Pass all trials from child experiment to parent experiment
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        return trials
+
+    def to_dict(self):
+        """Provide the configuration of the adapter as a dictionary
+
+        .. seealso::
+
+            :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
+        """
+        ret = dict(
+            of_type=self.__class__.__name__.lower())
+        return ret
+
+
+class CodeChange(BaseAdapter):
+    """Adapter which filters parent's trials based on the type of code change
+
+    This adapter let pass all trials if the code change didn't break the compatibility with parent's
+    experiment. If the effect of the change is UNSURE, the trials may only pass from parent to child
+    but not from child to parent. This is to ensure parent experiment does not get corrupted with
+    possibly incompatible results.
+
+    On forward, the adapter filters out parent's trials if type of code change is BREAK.
+    On backward, the adapter filters out child's trials if type of code change is UNSURE or BREAK.
+
+    Attributes
+    ----------
+    change_type: `str`
+        Type of change of the code. Can be one of `CodeChange.NOEFFET`, `CodeChange.BREAK` or
+        `CodeChange.UNSURE`.
+
+    """
+
+    NOEFFECT = "noeffect"
+    BREAK = "break"
+    UNSURE = "unsure"
+    types = [NOEFFECT, BREAK, UNSURE]
+
+    def __init__(self, change_type):
+        """Initialize and check change type's validity
+
+        Parameters
+        ----------
+        change_type: `str`
+            Type of change of the code. Can be one of `CodeChange.NOEFFET`, `CodeChange.BREAK` or
+            `CodeChange.UNSURE`.
+
+        """
+        if change_type not in self.types:
+            raise ValueError("Invalid code change type '%s'. Should be one of %s" %
+                             (change_type, str(self.types)))
+
+        self.change_type = change_type
+
+    def forward(self, trials):
+        """Filter out parent's trials if type of code change is BREAK.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.forward`
+        """
+        if self.change_type == self.BREAK:
+            return []
+
+        return trials
+
+    def backward(self, trials):
+        """Filter out child's trials if type of code change is UNSURE or BREAK.
+
+        .. seealso::
+
+            :meth:`orion.core.evc.BaseAdapter.backward`
+        """
+        if self.change_type in [self.BREAK, self.UNSURE]:
+            return []
+
+        return trials
+
+    def to_dict(self):
+        """Provide the configuration of the adapter as a dictionary
+
+        .. seealso::
+
+            :meth:`orion.core.evc.adapters.BaseAdapter.to_dict`
+        """
+        ret = dict(
+            of_type=self.__class__.__name__.lower(),
+            change_type=self.change_type)
+        return ret
+
+
+# pylint: disable=too-few-public-methods,abstract-method
+class Adapter(BaseAdapter, metaclass=Factory):
+    """Class used to inject dependency on an adapter implementation.
+
+    .. seealso:: `orion.core.utils.Factory` metaclass and `BaseAlgorithm` interface.
+    """
+
+    @classmethod
+    def build(cls, adapter_dicts):
+        """Builder method for a list of adapters.
+
+        Parameters
+        ----------
+        adapter_dicts: list of `dict`
+            List of adapter representation in dictionary form as expected to be saved in a database.
+
+        Returns
+        -------
+        `orion.core.evc.adapters.CompositeAdapter`
+            An adapter which may contain many adapters
+
+        """
+        adapters = []
+        for adapter_dict in adapter_dicts:
+            if isinstance(adapter_dict, (list, tuple)):
+                adapter = Adapter.build(adapter_dict)
+            else:
+                adapter = cls(**adapter_dict)
+            adapters.append(adapter)
+
+        return CompositeAdapter(*adapters)

--- a/src/orion/core/evc/experiment.py
+++ b/src/orion/core/evc/experiment.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+# pylint:disable=protected-access
+"""
+:mod:`orion.core.evc.experiment` -- Experiment node for EVC
+===========================================================
+
+.. module:: experiment
+   :platform: Unix
+   :synopsis: Experiment nodes connecting experiments to the EVC tree
+
+The experiments are connected to one another through the experiment nodes. The former can be created
+standalone without an EVC tree. When connected to an `ExperimentNode`, the experiments gain access
+to trials of other experiments by using method `ExperimentNode.fetch_trials`.
+
+Helper functions are provided to fetch trials keeping the tree structure. Those can be helpful when
+analyzing an EVC tree.
+
+"""
+import functools
+import logging
+
+from orion.core.evc.tree import TreeNode
+from orion.core.worker.experiment import ExperimentView
+
+log = logging.getLogger(__name__)
+
+
+class ExperimentNode(TreeNode):
+    """Experiment node to connect experiments to EVC tree.
+
+    The node carries an experiment in attribute `item`. The node can be instantiated only using the
+    name of the experiment. The experiment will be created lazily on access to `node.item`.
+
+    Attributes
+    ----------
+    name: str
+        Name of the experiment
+    item: None or :class:`orion.core.worker.experiment.Experiment`
+        None if the experiment is not initialized yet. When initializing lazily, it creates an
+        `ExperimentView`.
+
+    .. seealso::
+
+        :py:class:`TreeNode` for tree-specific attributes and methods.
+
+    """
+
+    __slots__ = ('name', ) + TreeNode.__slots__
+
+    def __init__(self, name, experiment=None, parent=None, children=tuple()):
+        """Initialize experiment node with item, experiment, parent and children
+
+        .. seealso::
+            :class:`orion.core.evc.tree.TreeNode` for information about the attributes
+        """
+        super(ExperimentNode, self).__init__(experiment, parent, children)
+        self.name = name
+
+    @property
+    def item(self):
+        """Get the experiment associated to the node
+
+        Note that accessing `item` may trigger the lazy initialization of the experiment if it was
+        not done already.
+        """
+        if self._item is None:
+            self._item = ExperimentView(self.name)
+            self._item.connect_to_version_control_tree(self)
+
+        return self._item
+
+    @property
+    def adapter(self):
+        """Get the adapter of the experiment with respect to its parent"""
+        return self.item.refers["adapter"]
+
+    def fetch_trials(self, query, selection=None):
+        """Fetch trials recursively in the EVC tree
+
+        .. seealso::
+
+            :meth:`orion.core.worker.Experiment.fetch_trials` for more information about the
+            arguments.
+
+        """
+        trials_tree = fetch_trials_tree(self, query, selection)
+        adapt_trials(trials_tree)
+
+        return sum([node.item['trials'] for node in trials_tree.root], [])
+
+
+def _fetch_node_trials(experiment_node, parent_or_children, query, selection=None):
+    """Fetch trials from the current node and connect with parent or children
+
+    .. note::
+
+        To call with node.map to connect with parents or children
+
+    """
+    experiment_trials = experiment_node.item.fetch_trials(query, selection)
+
+    rval = {'trials': experiment_trials, 'experiment': experiment_node.item}
+
+    return rval, parent_or_children
+
+
+def fetch_trials_tree(experiment_node, query, selection=None):
+    """Fetch trials recursively from an experiment node
+
+    .. seealso::
+
+        :meth:`orion.core.evc.experiment.ExperimentNode.fetch_trials`
+
+    """
+    if experiment_node.parent is not None:
+        parent_trials_tree = experiment_node.parent.map(
+            functools.partial(_fetch_node_trials, query=query, selection=selection),
+            experiment_node.parent.parent)
+    else:
+        parent_trials_tree = None
+
+    children_trials_tree = experiment_node.map(
+        functools.partial(_fetch_node_trials, query=query, selection=selection),
+        experiment_node.children)
+    children_trials_tree.set_parent(parent_trials_tree)
+
+    return children_trials_tree
+
+
+def _adapt_parent_trials(node, parent_trials_node):
+    """Adapt trials from the parent recursively
+
+    .. note::
+
+        To call with node.map(fct, node.parent) to connect with parents
+
+    """
+    if parent_trials_node is not None:
+        adapter = node.item['experiment'].refers['adapter']
+        for parent in parent_trials_node.root:
+            parent.item['trials'] = adapter.forward(parent.item['trials'])
+
+    return node.item, parent_trials_node
+
+
+def _adapt_children_trials(node, children_trials_nodes):
+    """Adapt trials from the children recursively
+
+    .. note::
+
+        To call with node.map(fct, node.children) to connect with children
+
+    """
+    for child in children_trials_nodes:
+        adapter = child.item['experiment'].refers['adapter']
+        for subchild in child:  # Includes child itself
+            subchild.item['trials'] = adapter.backward(subchild.item['trials'])
+
+    return node.item, children_trials_nodes
+
+
+def adapt_trials(trials_tree):
+    """Adapt trials recursively so that they are all compatible with current experiment."""
+    trials_tree.map(_adapt_parent_trials, trials_tree.parent)
+    trials_tree.map(_adapt_children_trials, trials_tree.children)

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -1,0 +1,391 @@
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.evc.tree` -- Tree data structure for the experiment version control system
+===========================================================================================
+
+.. module:: evc
+   :platform: Unix
+   :synopsis: Tree data structure for the experiment version control system
+
+Experiment version control requires building trees of the experiments so
+that we can fetch trials from one experiment to another or navigate from
+one experiment to another to visualise different statistics.
+
+TreeNode and tree iterators support the tree data structure of the experiment version control.
+TreeNode is a generic class which can carry arbitrary python objects. It comes with basic methods to
+set parent and children. A method `map` allows to apply functions recursively on the tree in a
+generic manner.
+
+"""
+
+
+class PreOrderTraversal(object):
+    """Iterate on a tree in a pre-order traversal fashion
+
+    Attributes
+    ----------
+    stack: list of `orion.core.evc.tree.TreeNode`
+        Nodes logged during iteration
+
+    """
+
+    __slots__ = ('stack', )
+
+    def __init__(self, tree_node):
+        """Initialize the stack for iteration"""
+        self.stack = [tree_node]
+
+    def __iter__(self):
+        """Get the iterator"""
+        return self
+
+    def __next__(self):
+        """Get the next node in pre-order traversal"""
+        try:
+            node = self.stack.pop()
+        except IndexError:
+            raise StopIteration
+
+        self.stack += node.children[::-1]
+
+        return node
+
+
+class DepthFirstTraversal(object):
+    """Iterate on a tree in a pre-order traversal fashion
+
+    Attributes
+    ----------
+    stack: list of `orion.core.evc.tree.TreeNode`
+        Nodes logged during iteration
+    seen: set of `orion.core.evc.tree.TreeNode`
+        Nodes which have been returned during iteration
+
+    """
+
+    __slots__ = ('stack', 'seen')
+
+    def __init__(self, tree_node):
+        """Initialize the stack and set of seen nodes for iteration"""
+        self.stack = [tree_node]
+        self.seen = set()
+
+    def _compute_potential(self):
+        """Filter out seen nodes from the stack"""
+        if len(self.stack) == 0:
+            return []
+
+        return list(filter(lambda n: n not in self.seen, self.stack[-1].children))
+
+    def __iter__(self):
+        """Get the iterator"""
+        return self
+
+    def __next__(self):
+        """Get the next node in depth-first traversal"""
+        potential = self._compute_potential()
+        while len(self.stack) > 0 and len(potential) > 0:
+            self.stack += potential[::-1]
+            potential = self._compute_potential()
+
+        try:
+            node = self.stack.pop()
+        except IndexError:
+            raise StopIteration
+
+        self.seen.add(node)
+
+        return node
+
+
+class TreeNode(object):
+    r"""Tree node data structure
+
+    Nodes have an attribute item to carry arbitrary information. A node may only have one parent and
+    can have as many children as desired.
+
+    Parents can be set at initialiation or via `node.set_parent`. Setting a parent automatically set
+    the current node as the child of the parent.
+
+    Children can be set at initialiation or via `node.add_children`. Setting children automatically
+    set their parent as the current node.
+
+    Tree of nodes are iterable, by default with preorder traversal.
+
+    .. seealso::
+        `orion.core.evc.tree.PreOrderTraversal`
+        `orion.core.evc.tree.DepthFirstTraversal`
+
+    Attributes
+    ----------
+    item: object
+        Can be anything
+    parent: None or instance of `orion.core.evc.tree.TreeNode`
+        The parent of the current node, None if the current node is the root.
+    children: None or list of instances of `orion.core.evc.tree.TreeNode`
+        The children of the curent node.
+    root: instance of `orion.core.evc.tree.TreeNode`
+        The top node of the current tree. The root node returns itself.
+
+    Example
+    -------
+    .. code-block:: python
+        :linenos:
+
+        a = TreeNode("a")
+        b = TreeNode("b", a)
+        c = TreeNode("c", a)
+        d = TreeNode("d", a)
+        e = TreeNode("e", a)
+
+        f = TreeNode("f", b)
+        g = TreeNode("g", b)
+
+        h = TreeNode("h", e)
+
+        # Gives this tree
+        # a
+        # |   \  \   \
+        # b    c  d   e
+        # | \         |
+        # f  g        h
+
+        g.set_parent(e)
+
+        # Gives this tree
+        # a
+        # |  \  \   \
+        # b   c  d   e
+        # |          | \
+        # f          h g
+
+        c.add_children(h, g)
+
+        # Gives this tree
+        # a
+        # |  \    \   \
+        # b   c    d   e
+        # |   | \
+        # f   h  g
+
+        a.drop_children(c)
+
+        # Gives this tree
+        # a
+        # |  \   \
+        # b   d   e
+        # |
+        # f
+
+    """
+
+    __slots__ = ('_item', '_parent', '_children')
+
+    def __init__(self, item, parent=None, children=tuple()):
+        """Initialize node with item, parent and children
+
+        .. seealso::
+            :class:`orion.core.evc.tree.TreeNode` for information about the attributes
+        """
+        self._item = item
+        self._parent = None
+        self._children = []
+
+        self.set_parent(parent)
+        self.add_children(*children)
+
+    @property
+    def item(self):
+        """Get item of the node which may contain arbitrary objects"""
+        return self._item
+
+    @item.setter
+    def item(self, new_item):
+        """Set item of the node with arbitrary objects"""
+        self._item = new_item
+
+    @property
+    def parent(self):
+        """Get parent of the node, None if no parent"""
+        return self._parent
+
+    def drop_parent(self):
+        """Drop the parent of the node, do nothing if no parent
+
+        Note that the node will be removed from the children of the parent as well
+        """
+        if self.parent is not None:
+            self._parent.drop_children(self)
+
+    def set_parent(self, node):
+        """Set the parent of the node
+
+        Note that setting a new parent will have the effect of dropping the previous parent, hence
+        dropping this current node from the previous parent's children list.
+
+        .. seealso::
+            `orion.core.evc.tree.TreeNode.drop_parent`
+        """
+        if node is self.parent:
+            return
+
+        if node is not None and not isinstance(node, TreeNode):
+            raise TypeError("Cannot set parent to %s" % str(node))
+
+        if self.parent is not None:
+            self.drop_parent()
+
+        if node is not None:
+            node.add_children(self)
+
+    @property
+    def children(self):
+        """Get children of the node, empty list if no children"""
+        return self._children
+
+    def drop_children(self, *nodes):
+        """Drop the children of the node, do nothing if no parent
+
+        Note that the parent of the given node will be removed as well
+
+        Raises
+        ------
+        ValueError
+            If one of the given nodes is not a children of the current node.
+
+        """
+        for child in nodes:
+            del self._children[self.children.index(child)]
+            child._parent = None
+
+    def add_children(self, *nodes):
+        """Add children to the current node
+
+        Note that added children will have their parent set to the current node as well.
+
+        .. seealso::
+            `orion.core.evc.tree.TreeNode.drop_children`
+        """
+        for child in nodes:
+            if child is not None and not isinstance(child, TreeNode):
+                raise TypeError("Cannot add %s to children" % str(child))
+
+            if child not in self._children:
+                # TreeNode.set_parent uses add_children so using it here could cause an infinit
+                # recursion. add_children() gets the dirty job done.
+                child.drop_parent()
+                child._parent = self
+                self._children.append(child)
+
+    @property
+    def root(self):
+        """Get the root of the tree
+
+        Root node returns itself
+        """
+        if self.parent is None:
+            return self
+
+        return self.parent.root
+
+    def map(self, function, node):
+        r"""Apply a function recursively on the tree
+
+        The function can be applied upwards on parents or downwards on children. The direction is
+        defined by passing self.parent or self.children as the node argument.
+
+        Parameters
+        ----------
+        function : callable
+            Callable object to which will be passed current node plus the parent node of children
+            nodes of the result down or up the tree respectively
+            If map on parents, callable(self, rval_parent_node)
+            If map on children, callable(self, rval_children_nodes)
+        node: None, `orion.core.evc.TreeNode` or list
+            Can be either
+            `None`: function is applied on current node only
+            `self.parent`: function is applied recursively climbing up the tree until the root
+            `self.children`: function is applied recursively going down the tree until the leafs
+
+        Examples
+        --------
+        .. code-block:: python
+            :linenos:
+
+            # Tree structure
+            # a
+            # |   \  \   \
+            # b    c  d   e
+            # | \         |
+            # f  g        h
+            #
+
+            root = TreeNode(1)
+            b = TreeNode(1, root)
+            TreeNode(1, root)
+            TreeNode(1, root)
+            e = TreeNode(1, root)
+
+            f = TreeNode(1, b)
+            TreeNode(1, b)
+
+            h = TreeNode(1, e)
+
+            def increment(node, children):
+                for child in TreeNode(0, None, children):
+                    child.item += 1
+
+                return node.item + 1
+
+            # Should return
+            #
+            # 2
+            # |   \  \   \
+            # 3    3  3   3
+            # | \         |
+            # 4  4        4
+
+            rval = root.map(increment, root.children)
+            assert [node.item for node in rval] == [2, 3, 4, 4, 3, 3, 3, 4]
+
+            def increment_parent(node, parent):
+                if parent is not None:
+                    for parent in parent.root:
+                        parent.item += 1
+
+                return node.item + 1
+
+            # Should return
+            #
+            # 4
+            # |
+            # 3
+            # |
+            # 2
+
+            rval = f.map(increment_parent, f.parent)
+            assert [node.item for node in rval.root] == [4, 3, 2]
+
+            rval = h.map(increment_parent, h.parent)
+            assert [node.item for node in rval.root] == [4, 3, 2]
+
+        """
+        if node is None:
+            return TreeNode(function(self, None))
+        elif node is self.parent:
+            rval_node = node.map(function, node.parent)
+            return TreeNode(function(self, rval_node), rval_node)
+        elif node is self.children:
+            rval_nodes = [child.map(function, child.children) for child in self.children]
+            return TreeNode(function(self, rval_nodes), parent=None, children=rval_nodes)
+        else:
+            raise TypeError("Invalid nodes: %s" % str(node))
+
+    def __iter__(self):
+        """Iterate on the tree with pre-order traversal"""
+        return PreOrderTraversal(self)
+
+
+def flattened(trials_tree):
+    """Get a list of the tree items in pre-order traversal"""
+    return [node.item for node in trials_tree]

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -385,13 +385,16 @@ class TreeNode(object):
 
         """
         if node is None:
-            return TreeNode(function(self, None))
+            rval, _ = function(self, None)
+            return TreeNode(rval)
         elif node is self.parent:
-            rval_node = node.map(function, node.parent)
-            return TreeNode(function(self, rval_node), rval_node)
+            rval_parent_node = node.map(function, node.parent)
+            rval, parent_node = function(self, rval_parent_node)
+            return TreeNode(rval, parent_node)
         elif node is self.children:
-            rval_nodes = [child.map(function, child.children) for child in self.children]
-            return TreeNode(function(self, rval_nodes), parent=None, children=rval_nodes)
+            rval_children_nodes = [child.map(function, child.children) for child in self.children]
+            rval, children_nodes = function(self, rval_children_nodes)
+            return TreeNode(rval, parent=None, children=children_nodes)
         else:
             raise TypeError("Invalid nodes: %s" % str(node))
 

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -248,6 +248,8 @@ class TreeNode(object):
     def drop_children(self, *nodes):
         """Drop the children of the node, do nothing if no parent
 
+        If no nodes are passed, the method will drop all the children of the current node.
+
         Note that the parent of the given node will be removed as well
 
         Raises
@@ -256,7 +258,10 @@ class TreeNode(object):
             If one of the given nodes is not a children of the current node.
 
         """
-        for child in nodes:
+        if not nodes:
+            nodes = self.children
+
+        for child in list(nodes):
             del self._children[self.children.index(child)]
             # pylint: disable=protected-access
             child._parent = None

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -19,6 +19,7 @@ generic manner.
 """
 
 
+# pylint: disable=too-few-public-methods
 class PreOrderTraversal(object):
     """Iterate on a tree in a pre-order traversal fashion
 
@@ -51,6 +52,7 @@ class PreOrderTraversal(object):
         return node
 
 
+# pylint: disable=too-few-public-methods
 class DepthFirstTraversal(object):
     """Iterate on a tree in a pre-order traversal fashion
 
@@ -72,7 +74,7 @@ class DepthFirstTraversal(object):
 
     def _compute_potential(self):
         """Filter out seen nodes from the stack"""
-        if len(self.stack) == 0:
+        if not self.stack:
             return []
 
         return list(filter(lambda n: n not in self.seen, self.stack[-1].children))
@@ -84,7 +86,7 @@ class DepthFirstTraversal(object):
     def __next__(self):
         """Get the next node in depth-first traversal"""
         potential = self._compute_potential()
-        while len(self.stack) > 0 and len(potential) > 0:
+        while self.stack and potential:
             self.stack += potential[::-1]
             potential = self._compute_potential()
 
@@ -256,6 +258,7 @@ class TreeNode(object):
         """
         for child in nodes:
             del self._children[self.children.index(child)]
+            # pylint: disable=protected-access
             child._parent = None
 
     def add_children(self, *nodes):
@@ -269,6 +272,12 @@ class TreeNode(object):
         for child in nodes:
             if child is not None and not isinstance(child, TreeNode):
                 raise TypeError("Cannot add %s to children" % str(child))
+
+            # TreeNode.set_parent uses add_children so using it here could cause an infinit
+            # recursion. add_children() gets the dirty job done.
+            child.drop_parent()
+            # pylint: disable=protected-access
+            child._parent = self
 
             if child not in self._children:
                 # TreeNode.set_parent uses add_children so using it here could cause an infinit

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -394,7 +394,7 @@ class TreeNode(object):
             rval, children_nodes = function(self, rval_children_nodes)
             return TreeNode(rval, parent=None, children=children_nodes)
         else:
-            raise TypeError("Invalid nodes: %s" % str(node))
+            raise ValueError("Invalid nodes: %s" % str(node))
 
     def __iter__(self):
         """Iterate on the tree with pre-order traversal"""

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -347,7 +347,7 @@ class TreeNode(object):
                 for child in TreeNode(0, None, children):
                     child.item += 1
 
-                return node.item + 1
+                return node.item + 1, children
 
             # Should return
             #
@@ -365,7 +365,7 @@ class TreeNode(object):
                     for parent in parent.root:
                         parent.item += 1
 
-                return node.item + 1
+                return node.item + 1, parent
 
             # Should return
             #

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -306,10 +306,13 @@ class TreeNode(object):
         Parameters
         ----------
         function : callable
-            Callable object to which will be passed current node plus the parent node of children
-            nodes of the result down or up the tree respectively
+            Callable object to which will be passed the current node plus the parent node or the
+            children nodes, depending on the direction of function application.
             If map on parents, callable(self, rval_parent_node)
-            If map on children, callable(self, rval_children_nodes)
+            If map on children, callable(self, rval_children_nodes).
+            Note that the callable object is expected to return an object which will be set as the
+            current node's item (in the resulting tree), and the parent node or the children nodes
+            depending on the direction of function application.
         node: None, `orion.core.evc.TreeNode` or list
             Can be either
             `None`: function is applied on current node only

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -402,6 +402,17 @@ class TreeNode(object):
         """Iterate on the tree with pre-order traversal"""
         return PreOrderTraversal(self)
 
+    def __repr__(self):
+        """Represent the object as a string."""
+        parent = self.parent
+        if parent is not None:
+            parent = parent.item
+
+        children = [child.item for child in self.children]
+
+        return ("%s(%s, parent=%s, children=%s)" %
+                (self.__class__.__name__, str(self.item), str(parent), str(children)))
+
 
 def flattened(trials_tree):
     """Get a list of the tree items in pre-order traversal"""

--- a/src/orion/core/evc/tree.py
+++ b/src/orion/core/evc/tree.py
@@ -278,16 +278,11 @@ class TreeNode(object):
             if child is not None and not isinstance(child, TreeNode):
                 raise TypeError("Cannot add %s to children" % str(child))
 
-            # TreeNode.set_parent uses add_children so using it here could cause an infinit
-            # recursion. add_children() gets the dirty job done.
-            child.drop_parent()
-            # pylint: disable=protected-access
-            child._parent = self
-
             if child not in self._children:
                 # TreeNode.set_parent uses add_children so using it here could cause an infinit
                 # recursion. add_children() gets the dirty job done.
                 child.drop_parent()
+                # pylint: disable=protected-access
                 child._parent = self
                 self._children.append(child)
 

--- a/src/orion/core/io/database/__init__.py
+++ b/src/orion/core/io/database/__init__.py
@@ -209,6 +209,36 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
         pass
 
 
+# pylint: disable=too-few-public-methods
+class ReadOnlyDB(object):
+    """Read-only view on a database.
+
+    .. seealso::
+
+        :py:class:`orion.core.io.database.AbstractDB`
+    """
+
+    __slots__ = ('_database', )
+
+    #                     Attributes
+    valid_attributes = (["host", "name", "port", "username", "password"] +
+                        # Properties
+                        ["is_connected"] +
+                        # Methods
+                        ["initiate_connection", "close_connection", "read", "count"])
+
+    def __init__(self, database):
+        """Init method, see attributes of :class:`AbstractDB`."""
+        self._database = database
+
+    def __getattr__(self, attr):
+        """Get attribute only if valid"""
+        if attr not in self.valid_attributes:
+            raise AttributeError("Cannot access attribute %s on view-only experiments." % attr)
+
+        return getattr(self._database, attr)
+
+
 class DatabaseError(RuntimeError):
     """Exception type used to delegate responsibility from any database
     implementation's own Exception types.

--- a/src/orion/core/io/evc_builder.py
+++ b/src/orion/core/io/evc_builder.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+# pylint:disable=protected-access
+"""
+:mod:`orion.core.io.evc_builder` -- Builder of experiment version control tree
+==============================================================================
+
+.. module:: experiment
+   :platform: Unix
+   :synopsis: Builder of the experiment version control tree
+
+The EVCBuilder takes care of building a main experiment along with an EVC tree and connect them
+together.
+
+A user can define a root and some leafs that should be the extremums of the tree. Those can be
+different than the actual root and leafs of the global EVC tree, making the trimmed version a small
+subset of the global version.
+
+"""
+import getpass
+
+from orion.core.evc.experiment import ExperimentNode
+from orion.core.evc.tree import TreeNode
+from orion.core.io.database import Database
+from orion.core.io.experiment_builder import ExperimentBuilder
+
+
+class EVCBuilder(object):
+    """Builder of experiment version control trees using
+    :class:`orion.core.evc.experiment.ExperimentNode`
+
+    .. seealso::
+
+        `orion.core.io.experiment_builder` for more information on the process of building
+        experiments.
+
+        :class:`orion.core.evc.experiment`
+        :class:`orion.core.worker.experiment`
+    """
+
+    # pylint:disable=no-self-use
+    def fetch_root_name(self, cmdargs):
+        """Fetch root name to trim EVC tree"""
+        return cmdargs.get('root', None)
+
+    # pylint:disable=no-self-use
+    def fetch_leaf_names(self, cmdargs):
+        """Fetch leaf names to trim EVC tree"""
+        return cmdargs.get('leafs', None)
+
+    def build_trimmed_tree(self, experiment, cmdargs):
+        """Build a tree of `ExperimentNode` trimmed according to `root_name` and `leaf_names` found
+        in configuration
+        """
+        root_name = self.fetch_root_name(cmdargs)
+        leaf_names = self.fetch_leaf_names(cmdargs)
+
+        return build_trimmed_tree(experiment, root_name, leaf_names)
+
+    def connect_to_version_control_tree(self, experiment, cmdargs):
+        """Build the EVC and connect the experiment to it"""
+        experiment_node = self.build_trimmed_tree(experiment, cmdargs)
+        experiment.connect_to_version_control_tree(experiment_node)
+
+    def build_view_from(self, cmdargs):
+        """Build an experiment view based on global config and connect it to the EVC"""
+        experiment_view = ExperimentBuilder().build_view_from(cmdargs)
+        self.connect_to_version_control_tree(experiment_view, cmdargs)
+
+        return experiment_view
+
+    def build_from(self, cmdargs):
+        """Build an experiment based on config and connect it to the EVC"""
+        experiment = ExperimentBuilder().build_from(cmdargs)
+        self.connect_to_version_control_tree(experiment, cmdargs)
+
+        return experiment
+
+    def build_from_config(self, config):
+        """Build an experiment based on given config and connect it to the EVC"""
+        experiment = ExperimentBuilder().build_from_config(config)
+        self.connect_to_version_control_tree(experiment, config)
+
+        return experiment
+
+
+def fetch_nodes(experiment_id):
+    """Query all experiment documents which matches the root_id"""
+    query = {'refers.root_id': experiment_id, "metadata.user": getpass.getuser()}
+    selection = {'name': 1, 'refers.root_id': 1, 'refers.parent_id': 1}
+    nodes = Database().read('experiments', query, selection=selection)
+    return nodes
+
+
+def _fetch_root(root_id, free_nodes):
+    """Find the root in the set of nodes"""
+    root = None
+
+    for node in list(free_nodes):
+        if node['_id'] == root_id:
+            root = free_nodes.pop(free_nodes.index(node))
+            break
+
+    if root is None:
+        raise ValueError("Found no experiment with id '%s'" % str(root_id))
+
+    return root
+
+
+def build_tree(root_id, nodes, root=None):
+    """Find the root in the set of nodes"""
+    free_nodes = nodes
+
+    if root is None:
+        root = _fetch_root(root_id, free_nodes)
+
+    children = []
+    for node in nodes[:]:
+        if node['refers']['parent_id'] == root_id:
+            children.append(free_nodes.pop(free_nodes.index(node)))
+
+    root = TreeNode(root['name'])
+
+    for child in children:
+        root.add_children(build_tree(child['_id'], free_nodes, child))
+
+    return root
+
+
+def trim_tree(root_node, experiment_name, root_name=None, leaf_names=tuple()):
+    """Trim the tree by removing nodes above a given root name and below given leaf names.
+
+    If `root_name` is `None`, the nothing will be trimmed at the root. If `leaf_names` is an empty
+    iterator, nothing will be trimmed the at the leafs.
+
+    Parameters
+    ----------
+    root_node: `orion.core.evc.tree.TreeNode`
+        The root node of the tree to trim.
+    experiment_name: str
+        Name of the current experiment. May not be the root.
+    root_name: str
+        Name of the root at which the function should trim. If `None`, the tree won't be trimmed at
+        its root. Defaults to `None`.
+    leaf_names: tuple or list of str
+        Name of the leafs at which the function should trim. Only the paths leading to the specified
+        leafs will be kept.
+
+    Raises
+    ------
+    RuntimeError
+        Raise if the given `root_name` of the given `leaf_names` are not found in the tree.
+
+    """
+    if root_name is None:
+        root_name = root_node.item
+
+    experiment_node = None
+
+    for node in list(root_node):
+        if node.item == experiment_name:
+            experiment_node = node
+            break
+
+    def trim_parent(node, parent):
+        """Remove the parent if not on the path to specified root"""
+        if parent is not None and parent.root.item != root_name:
+            return node.item, None
+
+        return node.item, parent
+
+    trimmed_parent = experiment_node.map(trim_parent, experiment_node.parent).parent
+    if trimmed_parent is not None:
+        trimmed_parent.drop_children()
+    experiment_node.set_parent(trimmed_parent)
+
+    def trim_children(node, children):
+        """Remove the children if not on the path to specified leafs"""
+        trimmed_children = []
+        for child in list(children):
+            if child.children or child.item in leaf_names:
+                trimmed_children.append(child)
+
+        return node.item, trimmed_children
+
+    if leaf_names:
+        trimmed_children = experiment_node.map(trim_children, experiment_node.children)
+        experiment_node.drop_children()
+        experiment_node.add_children(*trimmed_children.children)
+
+    unseen = set([root_name] + leaf_names)
+
+    for node in experiment_node.root:
+        if node.item in unseen:
+            unseen.remove(node.item)
+
+    if unseen:
+        raise RuntimeError("Some experiments were not found: %s" % str(unseen))
+
+    return experiment_node
+
+
+def convert_to_experiment_nodes(experiment_node):
+    """Convert shallow `TreeNode` into initializable `ExperimentNode`"""
+    def _convert_children_to_experiment_nodes(node, children):
+        """Convert the children to `ExperimentNode`"""
+        converted_children = []
+        for child in children:
+            converted_children.append(ExperimentNode(child.item, children=child.children))
+
+        return node.item, converted_children
+
+    def _convert_parent_to_experiment_nodes(node, parent):
+        """Convert the parent to `ExperimentNode`"""
+        if parent is None:
+            return node.item, None
+
+        grand_parent = parent.parent
+        if grand_parent is not None:
+            grand_parent.drop_children()
+
+        return node.item, ExperimentNode(parent.item, parent=grand_parent)
+
+    parent = experiment_node.parent
+    if parent is not None:
+        parent = experiment_node.map(_convert_parent_to_experiment_nodes,
+                                     experiment_node.parent).parent
+        parent.drop_children()
+
+    children_nodes = experiment_node.map(_convert_children_to_experiment_nodes,
+                                         experiment_node.children).children
+
+    return ExperimentNode(experiment_node.item, parent=parent, children=children_nodes)
+
+
+def build_trimmed_tree(experiment, root_name, leaf_names):
+    """Build a trimmed tree for the EVC of a given experiment
+
+    .. seealso::
+        `orion.core.io.evc_builder.trim_tree` for more information about the arguments.
+
+    """
+    nodes = fetch_nodes(experiment.refers['root_id'])
+    root_node = build_tree(experiment.refers['root_id'], nodes)
+    exp_tree_node = trim_tree(root_node, experiment.name, root_name, leaf_names)
+
+    return convert_to_experiment_nodes(exp_tree_node)

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -253,7 +253,6 @@ class ExperimentBuilder(object):
         # Pop out configuration concerning databases and resources
         config.pop('database', None)
         config.pop('resources', None)
-        config.pop('status', None)
 
         experiment = Experiment(config['name'])
 

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -1,0 +1,279 @@
+# -*- coding: utf-8 -*-
+# pylint:disable=protected-access
+"""
+:mod:`orion.core.io.experiment_builder` -- Create experiment from user options
+==============================================================================
+
+.. module:: experiment
+   :platform: Unix
+   :synopsis: Functions which build `Experiment` and `ExperimentView` objects
+       based on user configuration.
+
+
+The instantiation of an `Experiment` is not a trivial process when the user request an experiment
+with specific options. One can easily create a new experiment with
+`ExperimentView('some_experiment_name')`, but the configuration of a _writable_ experiment is less
+straighforward. This is because there is many sources of configuration and they have a strict
+hierarchy. From the more global to the more specific, there is:
+
+1. Global configuration:
+    Defined by `src.orion.core.io.resolve_config.DEF_CONFIG_FILES_PATHS`.
+    Can be scattered in user file system, defaults could look like:
+        - `/some/path/to/.virtualenvs/orion/share/orion.core`
+        - `/etc/xdg/xdg-ubuntu/orion.core`
+        - `/home/${USER}/.config/orion.core`
+
+    Note that some variables have default value even if user do not defined them in global
+    configuration:
+        - `max_trials = src.orion.core.io.resolve_config.DEF_CMD_MAX_TRIALS`
+        - `pool_size = src.orion.core.io.resolve_config.DEF_CMD_POOL_SIZE`
+        - `algorithms = random`
+        - Database specific:
+            * `datbase.name = 'orion'`
+            * `database.type = 'MongoDB'`
+            * `database.host = ${HOST}`
+
+2. Oríon specific environment variables:
+    Environment variables which can override global configuration
+    - Database specific:
+        * `ORION_DB_NAME`
+        * `ORION_DB_TYPE`
+        * `ORION_DB_ADDRESS`
+
+3. Experiment configuration inside the database
+    Configuration of the experiment if present in the database.
+    Making this part of the configuration of the experiment makes it possible
+    for the user to execute an experiment by only specifying partial configuration. The rest of the
+    configuration is fetched from the database.
+
+    For example, a user could:
+
+    1. Rerun the same experiment
+        Only providing the name is sufficient to rebuild the entire configuration of the
+        experiment.
+
+    2. Make a modification to an existing experiment
+        The user can provide the name of the existing experiment and only provide the changes to
+        apply on it. Here is an minimal example where we fully initialize a first experiment with a
+        config file and then branch from it with minimal information.
+
+        .. code-block:: bash
+
+            # Initialize root experiment
+            orion init_only --config previous_exeriment.yaml ./userscript -x~'uniform(0, 10)'
+            # Branch a new experiment
+            orion hunt -n previous_experiment ./userscript -x~'uniform(0, 100)'
+
+4. Configuration file
+    This configuration file is meant to overwrite the configuration coming from the database.
+    If this configuration file was interpreted as part of the global configuration, a user could
+    only modify an experiment using command line arguments.
+
+5. Command-line arguments
+    Those are the arguments provided to `orion` for any method (hunt, insert, etc). It includes the
+    argument to `orion` itself as well as the user's script name and its arguments.
+
+"""
+import datetime
+import getpass
+import logging
+import os
+
+import orion
+from orion.core.io import resolve_config
+from orion.core.io.database import Database, DuplicateKeyError
+from orion.core.worker.experiment import Experiment, ExperimentView
+
+
+log = logging.getLogger(__name__)
+
+
+class ExperimentBuilder(object):
+    """Builder for :class:`orion.core.worker.experiment.Experiment`
+    and :class:`orion.core.worker.experiment.ExperimentView`
+
+    .. seealso::
+
+        `orion.core.io.experiment_builder` for more information on the process of building
+        experiments.
+
+        :class:`orion.core.worker.experiment.Experiment`
+        :class:`orion.core.worker.experiment.ExperimentView`
+    """
+
+    # pylint:disable=no-self-use
+    def fetch_default_options(self):
+        """Get dictionary of default options"""
+        return resolve_config.fetch_default_options()
+
+    # pylint:disable=no-self-use
+    def fetch_env_vars(self):
+        """Get dictionary of environment variables specific to Oríon"""
+        return resolve_config.fetch_env_vars()
+
+    def fetch_file_config(self, cmdargs):
+        """Get dictionary of options from configuration file provided in command-line"""
+        return resolve_config.fetch_config(cmdargs)
+
+    def fetch_local_config(self, cmdargs):
+        """Get dictionary of options from all local sources (not from db)
+
+        .. seealso::
+
+            `orion.core.io.experiment_builder` for more information on the hierarchy of
+            configurations.
+        """
+        default_options = self.fetch_default_options()
+        env_vars = self.fetch_env_vars()
+        cmdconfig = self.fetch_file_config(cmdargs)
+
+        return resolve_config.merge_configs(default_options, env_vars, cmdconfig, cmdargs)
+
+    def fetch_db_config(self, cmdargs):
+        """Get dictionary of options from all local sources (not from db)
+
+        Note
+        ----
+            This method builds an experiment view in the background to fetch the configuration from
+            the database.
+        """
+        try:
+            experiment_view = self.build_view_from(cmdargs)
+        except ValueError as e:
+            if "No experiment with given name" in str(e):
+                return {}
+
+        return experiment_view.configuration
+
+    def fetch_full_config(self, cmdargs):
+        """Get dictionary of the full configuration of the experiment.
+
+        .. seealso::
+
+            `orion.core.io.experiment_builder` for more information on the hierarchy of
+            configurations.
+
+        Note
+        ----
+            This method builds an experiment view in the background to fetch the configuration from
+            the database.
+        """
+        default_options = self.fetch_default_options()
+        env_vars = self.fetch_env_vars()
+        db_config = self.fetch_db_config(cmdargs)
+        cmdconfig = self.fetch_file_config(cmdargs)
+
+        exp_config = resolve_config.merge_configs(
+            default_options, env_vars, db_config, cmdconfig, cmdargs)
+
+        # Infer rest information about the process + versioning
+        if 'metadata' not in exp_config:
+            exp_config['metadata'] = {}
+
+        exp_config['metadata']['orion_version'] = orion.core.__version__
+
+        # Move 'user_script' and 'user_args' to 'metadata' key
+        user_script = exp_config.pop('user_script', None)
+        if user_script:
+            abs_user_script = os.path.abspath(user_script)
+            if resolve_config.is_exe(abs_user_script):
+                user_script = abs_user_script
+
+        exp_config['metadata']['user_script'] = user_script
+        exp_config['metadata']['user_args'] = exp_config.pop('user_args', None)
+
+        exp_config['metadata']['user'] = getpass.getuser()
+
+        if 'datetime' not in exp_config['metadata']:
+            exp_config['metadata']['datetime'] = datetime.datetime.utcnow()
+
+        exp_config['metadata'] = resolve_config.infer_versioning_metadata(exp_config['metadata'])
+
+        return exp_config
+
+    def build_view_from(self, cmdargs):
+        """Build an experiment view based on full configuration.
+
+        .. seealso::
+
+            `orion.core.io.experiment_builder` for more information on the hierarchy of
+            configurations.
+
+            :class:`orion.core.worker.experiment.ExperimentView` for more information on the
+            experiment view object.
+        """
+        local_config = self.fetch_local_config(cmdargs)
+
+        db_opts = local_config['database']
+        dbtype = db_opts.pop('type')
+
+        # Information should be enough to infer experiment's name.
+        log.debug("Creating %s database client with args: %s", dbtype, db_opts)
+        try:
+            Database(of_type=dbtype, **db_opts)
+        except ValueError:
+            if Database().__class__.__name__.lower() != dbtype.lower():
+                raise
+
+        exp_name = local_config['name']
+        if exp_name is None:
+            raise RuntimeError("Could not infer experiment's name. "
+                               "Please use either `name` cmd line arg or provide "
+                               "one in orion's configuration file.")
+
+        return ExperimentView(local_config["name"])
+
+    def build_from(self, cmdargs):
+        """Build a fully configured (and writable) experiment based on full configuration.
+
+        .. seealso::
+
+            `orion.core.io.experiment_builder` for more information on the hierarchy of
+            configurations.
+
+            :class:`orion.core.worker.experiment.Experiment` for more information on the experiment
+            object.
+        """
+        full_config = self.fetch_full_config(cmdargs)
+
+        log.info(full_config)
+
+        # Pop out configuration concerning databases and resources
+        full_config.pop('database', None)
+        full_config.pop('resources', None)
+        full_config.pop('status', None)
+
+        return self.build_from_config(full_config)
+
+    def build_from_config(self, config):
+        """Build a fully configured (and writable) experiment based on full configuration.
+
+        .. seealso::
+
+            `orion.core.io.experiment_builder` for more information on the hierarchy of
+            configurations.
+
+            :class:`orion.core.worker.experiment.Experiment` for more information on the experiment
+            object.
+        """
+        log.info(config)
+
+        # Pop out configuration concerning databases and resources
+        config.pop('database', None)
+        config.pop('resources', None)
+        config.pop('status', None)
+
+        experiment = Experiment(config['name'])
+
+        # Finish experiment's configuration and write it to database.
+        try:
+            experiment.configure(config)
+        except DuplicateKeyError:
+            # Fails if concurrent experiment with identical (name, metadata.user)
+            # is written first in the database.
+            # Next build_from_config() should either load experiment from database
+            # and run smoothly if identical or trigger an experiment fork.
+            # In other words, there should not be more than 1 level of recursion.
+            experiment = self._build_from_config(config)
+
+        return experiment

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -17,61 +17,73 @@ straighforward. This is because there is many sources of configuration and they 
 hierarchy. From the more global to the more specific, there is:
 
 1. Global configuration:
-    Defined by `src.orion.core.io.resolve_config.DEF_CONFIG_FILES_PATHS`.
-    Can be scattered in user file system, defaults could look like:
-        - `/some/path/to/.virtualenvs/orion/share/orion.core`
-        - `/etc/xdg/xdg-ubuntu/orion.core`
-        - `/home/${USER}/.config/orion.core`
 
-    Note that some variables have default value even if user do not defined them in global
-    configuration:
-        - `max_trials = src.orion.core.io.resolve_config.DEF_CMD_MAX_TRIALS`
-        - `pool_size = src.orion.core.io.resolve_config.DEF_CMD_POOL_SIZE`
-        - `algorithms = random`
-        - Database specific:
-            * `database.name = 'orion'`
-            * `database.type = 'MongoDB'`
-            * `database.host = ${HOST}`
+  Defined by `src.orion.core.io.resolve_config.DEF_CONFIG_FILES_PATHS`.
+  Can be scattered in user file system, defaults could look like:
+
+    - `/some/path/to/.virtualenvs/orion/share/orion.core`
+    - `/etc/xdg/xdg-ubuntu/orion.core`
+    - `/home/${USER}/.config/orion.core`
+
+  Note that some variables have default value even if user do not defined them in global
+  configuration:
+
+    - `max_trials = src.orion.core.io.resolve_config.DEF_CMD_MAX_TRIALS`
+    - `pool_size = src.orion.core.io.resolve_config.DEF_CMD_POOL_SIZE`
+    - `algorithms = random`
+    - Database specific:
+
+      * `database.name = 'orion'`
+      * `database.type = 'MongoDB'`
+      * `database.host = ${HOST}`
 
 2. Oríon specific environment variables:
-    Environment variables which can override global configuration
+
+   Environment variables which can override global configuration
+
     - Database specific:
-        * `ORION_DB_NAME`
-        * `ORION_DB_TYPE`
-        * `ORION_DB_ADDRESS`
+
+      * `ORION_DB_NAME`
+      * `ORION_DB_TYPE`
+      * `ORION_DB_ADDRESS`
 
 3. Experiment configuration inside the database
-    Configuration of the experiment if present in the database.
-    Making this part of the configuration of the experiment makes it possible
-    for the user to execute an experiment by only specifying partial configuration. The rest of the
-    configuration is fetched from the database.
 
-    For example, a user could:
+  Configuration of the experiment if present in the database.
+  Making this part of the configuration of the experiment makes it possible
+  for the user to execute an experiment by only specifying partial configuration. The rest of the
+  configuration is fetched from the database.
+
+  For example, a user could:
 
     1. Rerun the same experiment
-        Only providing the name is sufficient to rebuild the entire configuration of the
-        experiment.
+
+      Only providing the name is sufficient to rebuild the entire configuration of the
+      experiment.
 
     2. Make a modification to an existing experiment
-        The user can provide the name of the existing experiment and only provide the changes to
-        apply on it. Here is an minimal example where we fully initialize a first experiment with a
-        config file and then branch from it with minimal information.
 
-        .. code-block:: bash
+      The user can provide the name of the existing experiment and only provide the changes to
+      apply on it. Here is an minimal example where we fully initialize a first experiment with a
+      config file and then branch from it with minimal information.
 
-            # Initialize root experiment
-            orion init_only --config previous_exeriment.yaml ./userscript -x~'uniform(0, 10)'
-            # Branch a new experiment
-            orion hunt -n previous_experiment ./userscript -x~'uniform(0, 100)'
+      .. code-block:: bash
+
+          # Initialize root experiment
+          orion init_only --config previous_exeriment.yaml ./userscript -x~'uniform(0, 10)'
+          # Branch a new experiment
+          orion hunt -n previous_experiment ./userscript -x~'uniform(0, 100)'
 
 4. Configuration file
-    This configuration file is meant to overwrite the configuration coming from the database.
-    If this configuration file was interpreted as part of the global configuration, a user could
-    only modify an experiment using command line arguments.
+
+  This configuration file is meant to overwrite the configuration coming from the database.
+  If this configuration file was interpreted as part of the global configuration, a user could
+  only modify an experiment using command line arguments.
 
 5. Command-line arguments
-    Those are the arguments provided to `orion` for any method (hunt, insert, etc). It includes the
-    argument to `orion` itself as well as the user's script name and its arguments.
+
+  Those are the arguments provided to `orion` for any method (hunt, insert, etc). It includes the
+  argument to `orion` itself as well as the user's script name and its arguments.
 
 """
 import logging

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -125,8 +125,8 @@ class ExperimentBuilder(object):
 
         return resolve_config.merge_configs(default_options, env_vars, cmdconfig, cmdargs)
 
-    def fetch_db_config(self, cmdargs):
-        """Get dictionary of options from all local sources (not from db)
+    def fetch_config_from_db(self, cmdargs):
+        """Get dictionary of options from experiment found in the database
 
         Note
         ----
@@ -161,12 +161,12 @@ class ExperimentBuilder(object):
         """
         default_options = self.fetch_default_options()
         env_vars = self.fetch_env_vars()
-        db_config = self.fetch_db_config(cmdargs)
+        config_from_db = self.fetch_config_from_db(cmdargs)
         cmdconfig = self.fetch_file_config(cmdargs)
         metadata = dict(metadata=self.fetch_metadata(cmdargs))
 
         exp_config = resolve_config.merge_configs(
-            default_options, env_vars, db_config, cmdconfig, cmdargs, metadata)
+            default_options, env_vars, config_from_db, cmdconfig, cmdargs, metadata)
 
         return exp_config
 

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -184,9 +184,6 @@ class ExperimentBuilder(object):
 
         exp_config['metadata']['user'] = getpass.getuser()
 
-        if 'datetime' not in exp_config['metadata']:
-            exp_config['metadata']['datetime'] = datetime.datetime.utcnow()
-
         exp_config['metadata'] = resolve_config.infer_versioning_metadata(exp_config['metadata'])
 
         return exp_config

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -74,12 +74,8 @@ hierarchy. From the more global to the more specific, there is:
     argument to `orion` itself as well as the user's script name and its arguments.
 
 """
-import datetime
-import getpass
 import logging
-import os
 
-import orion
 from orion.core.io import resolve_config
 from orion.core.io.database import Database, DuplicateKeyError
 from orion.core.worker.experiment import Experiment, ExperimentView
@@ -145,6 +141,10 @@ class ExperimentBuilder(object):
 
         return experiment_view.configuration
 
+    def fetch_metadata(self, cmdargs):
+        """Infer rest information about the process + versioning"""
+        return resolve_config.fetch_metadata(cmdargs)
+
     def fetch_full_config(self, cmdargs):
         """Get dictionary of the full configuration of the experiment.
 
@@ -157,34 +157,16 @@ class ExperimentBuilder(object):
         ----
             This method builds an experiment view in the background to fetch the configuration from
             the database.
+
         """
         default_options = self.fetch_default_options()
         env_vars = self.fetch_env_vars()
         db_config = self.fetch_db_config(cmdargs)
         cmdconfig = self.fetch_file_config(cmdargs)
+        metadata = dict(metadata=self.fetch_metadata(cmdargs))
 
         exp_config = resolve_config.merge_configs(
-            default_options, env_vars, db_config, cmdconfig, cmdargs)
-
-        # Infer rest information about the process + versioning
-        if 'metadata' not in exp_config:
-            exp_config['metadata'] = {}
-
-        exp_config['metadata']['orion_version'] = orion.core.__version__
-
-        # Move 'user_script' and 'user_args' to 'metadata' key
-        user_script = exp_config.pop('user_script', None)
-        if user_script:
-            abs_user_script = os.path.abspath(user_script)
-            if resolve_config.is_exe(abs_user_script):
-                user_script = abs_user_script
-
-        exp_config['metadata']['user_script'] = user_script
-        exp_config['metadata']['user_args'] = exp_config.pop('user_args', None)
-
-        exp_config['metadata']['user'] = getpass.getuser()
-
-        exp_config['metadata'] = resolve_config.infer_versioning_metadata(exp_config['metadata'])
+            default_options, env_vars, db_config, cmdconfig, cmdargs, metadata)
 
         return exp_config
 

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -244,6 +244,6 @@ class ExperimentBuilder(object):
             # Next build_from_config() should either load experiment from database
             # and run smoothly if identical or trigger an experiment fork.
             # In other words, there should not be more than 1 level of recursion.
-            experiment = self._build_from_config(config)
+            experiment = self.build_from_config(config)
 
         return experiment

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -29,7 +29,7 @@ hierarchy. From the more global to the more specific, there is:
         - `pool_size = src.orion.core.io.resolve_config.DEF_CMD_POOL_SIZE`
         - `algorithms = random`
         - Database specific:
-            * `datbase.name = 'orion'`
+            * `database.name = 'orion'`
             * `database.type = 'MongoDB'`
             * `database.host = ${HOST}`
 

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -81,10 +81,11 @@ ENV_VARS = dict(
 
 def fetch_config(args):
     """Return the config inside the .yaml file if present."""
-    orion_file = args.pop('config')
+    orion_file = args.get('config')
     config = dict()
     if orion_file:
         log.debug("Found orion configuration file at: %s", os.path.abspath(orion_file.name))
+        orion_file.seek(0)
         config = yaml.safe_load(orion_file)
 
     return config

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -31,6 +31,7 @@ precedence is respected when building the settings dictionary:
 .. note:: `Optimization` entries are required, `Dynamic` entry is optional.
 
 """
+import getpass
 import logging
 import os
 import socket
@@ -153,6 +154,27 @@ def fetch_env_vars():
                 env_vars[signif][key] = value
 
     return env_vars
+
+
+def fetch_metadata(cmdargs):
+    """Infer rest information about the process + versioning"""
+    metadata = {}
+
+    metadata['orion_version'] = orion.core.__version__
+
+    # Move 'user_script' and 'user_args' to 'metadata' key
+    user_script = cmdargs.get('user_script', None)
+    if user_script:
+        abs_user_script = os.path.abspath(user_script)
+        if is_exe(abs_user_script):
+            user_script = abs_user_script
+
+    metadata['user_script'] = user_script
+    metadata['user_args'] = cmdargs.get('user_args', None)
+
+    metadata['user'] = getpass.getuser()
+
+    return infer_versioning_metadata(metadata)
 
 
 def merge_configs(*configs):

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -139,14 +139,6 @@ def fetch_default_options():
     return default_config
 
 
-def merge_env_vars(config):
-    """Fetch environmental variables related to orion's managerial data.
-
-    :type config: :func:`nesteddict`
-    """
-    return merge_configs(config, fetch_env_vars())
-
-
 def fetch_env_vars():
     """Fetch environmental variables related to orion's managerial data."""
     env_vars = {}
@@ -161,39 +153,6 @@ def fetch_env_vars():
                 env_vars[signif][key] = value
 
     return env_vars
-
-
-def merge_orion_config(config, dbconfig, cmdconfig, cmdargs):
-    """
-    Oríon Configuration
-    -------------------
-
-    name --  Experiment's name.
-
-       If you provide a past experiment's name,
-       then that experiment will be resumed. This means that its history of
-       trials will be reused, along with any configurations logged in the
-       database which are not overwritten by current call to `orion` script.
-
-    max_trials -- Maximum number of trial evaluations to be computed
-
-       (required as a cmd line argument or a orion_config parameter)
-
-    pool_size -- Number of workers evaluating in parallel asychronously
-
-       (default: 10 @ default resource). Can be a dict of the form:
-       {resource_alias: subpool_size}
-
-    database -- dict with keys: 'type', 'name', 'host', 'port', 'username', 'password'
-
-    resources -- {resource_alias: (entry_address, scheduler, scheduler_ops)} (optional)
-
-    algorithm -- {optimizer module name : method-specific configuration}
-
-    .. seealso:: Method-specific configurations reside in `/config`
-
-    """
-    return merge_configs(config, dbconfig, cmdconfig, cmdargs)
 
 
 def merge_configs(*configs):

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -31,13 +31,9 @@ precedence is respected when building the settings dictionary:
 .. note:: `Optimization` entries are required, `Dynamic` entry is optional.
 
 """
-import argparse
-from collections import defaultdict
-from copy import deepcopy
 import logging
 import os
 import socket
-import textwrap
 
 from numpy import inf as infinity
 import yaml
@@ -87,54 +83,6 @@ ENV_VARS_DB = [
 ENV_VARS = dict(
     database=ENV_VARS_DB
     )
-################################################################################
-#                           Input Parsing Functions                            #
-################################################################################
-
-
-class OrionArgsParser:
-    """Parser object handling the upper-level parsing of Oríon's arguments."""
-
-    def __init__(self, description):
-        """Create the pre-command arguments"""
-        self.description = description
-
-        self.parser = argparse.ArgumentParser(
-            formatter_class=argparse.RawDescriptionHelpFormatter,
-            description=textwrap.dedent(description))
-
-        self.parser.add_argument(
-            '-V', '--version',
-            action='version', version='orion ' + orion.core.__version__)
-
-        self.parser.add_argument(
-            '-v', '--verbose',
-            action='count', default=0,
-            help="logging levels of information about the process (-v: INFO. -vv: DEBUG)")
-
-        self.subparsers = self.parser.add_subparsers(help='sub-command help')
-
-    def get_subparsers(self):
-        """Return the subparser object for this parser."""
-        return self.subparsers
-
-    def parse(self, argv):
-        """Call argparse and generate a dictionary of arguments' value"""
-        args = vars(self.parser.parse_args(argv))
-
-        verbose = args.pop('verbose', 0)
-        if verbose == 1:
-            logging.basicConfig(level=logging.INFO)
-        elif verbose == 2:
-            logging.basicConfig(level=logging.DEBUG)
-
-        function = args.pop('func')
-        return args, function
-
-    def execute(self, argv):
-        """Execute main function of the subparser"""
-        args, function = self.parse(argv)
-        function(args)
 
 
 def fetch_config(args):
@@ -146,49 +94,6 @@ def fetch_config(args):
         config = yaml.safe_load(orion_file)
 
     return config
-
-
-def get_basic_args_group(parser):
-    """Return the basic arguments for any command."""
-    basic_args_group = parser.add_argument_group(
-        "Oríon arguments (optional)",
-        description="These arguments determine orion's behaviour")
-
-    basic_args_group.add_argument(
-        '-n', '--name',
-        type=str, metavar='stringID',
-        help="experiment's unique name; "
-             "(default: None - specified either here or in a config)")
-
-    basic_args_group.add_argument('-c', '--config', type=argparse.FileType('r'),
-                                  metavar='path-to-config', help="user provided "
-                                  "orion configuration file")
-
-    return basic_args_group
-
-
-def get_user_args_group(parser):
-    """
-    Return the user group arguments for any command.
-    User group arguments are composed of the user script and the user args
-    """
-    usergroup = parser.add_argument_group(
-        "User script related arguments",
-        description="These arguments determine user's script behaviour "
-                    "and they can serve as orion's parameter declaration.")
-
-    usergroup.add_argument(
-        'user_script', type=str, metavar='path-to-script',
-        help="your experiment's script")
-
-    usergroup.add_argument(
-        'user_args', nargs=argparse.REMAINDER, metavar='...',
-        help="Command line arguments to your script (if any). A configuration "
-             "file intended to be used with 'userscript' must be given as a path "
-             "in the **first positional** argument OR using `--config=<path>` "
-             "keyword argument.")
-
-    return usergroup
 
 
 def fetch_default_options():
@@ -252,6 +157,10 @@ def merge_env_vars(config):
     return newcfg
 
 
+def merge_configs(*configs):
+    raise NotImplementedError
+
+
 def merge_orion_config(config, dbconfig, cmdconfig, cmdargs):
     """
     Oríon Configuration
@@ -301,3 +210,11 @@ def merge_orion_config(config, dbconfig, cmdconfig, cmdargs):
                 expconfig[k] = v
 
     return expconfig
+
+
+def infer_versioning_metadata(existing_metadata):
+    """Infer information about user's script versioning if available."""
+    # VCS system
+    # User repo's version
+    # User repo's HEAD commit hash
+    return existing_metadata

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -41,12 +41,6 @@ import yaml
 import orion
 
 
-# Define type of arbitrary nested defaultdicts
-def nesteddict():
-    """Extend defaultdict to arbitrary nested levels."""
-    return defaultdict(nesteddict)
-
-
 def is_exe(path):
     """Test whether `path` describes an executable file."""
     return os.path.isfile(path) and os.access(path, os.X_OK)
@@ -97,7 +91,7 @@ def fetch_config(args):
 
 
 def fetch_default_options():
-    """Create a nesteddict with options from the default configuration files.
+    """Create a dict with options from the default configuration files.
 
     Respect precedence from application's default, to system's and
     user's.
@@ -105,7 +99,7 @@ def fetch_default_options():
     .. seealso:: :const:`DEF_CONFIG_FILES_PATHS`
 
     """
-    default_config = nesteddict()
+    default_config = dict()
 
     # get some defaults
     default_config['name'] = None
@@ -115,6 +109,7 @@ def fetch_default_options():
 
     # get default options for some managerial variables (see :const:`ENV_VARS`)
     for signifier, env_vars in ENV_VARS.items():
+        default_config[signifier] = {}
         for _, key, default_value in env_vars:
             default_config[signifier][key] = default_value
 
@@ -128,6 +123,7 @@ def fetch_default_options():
                 # implies that yaml must be in dict form
                 for k, v in cfg.items():
                     if k in ENV_VARS:
+                        default_config[k] = {}
                         for vk, vv in v.items():
                             default_config[k][vk] = vv
                     else:
@@ -146,19 +142,24 @@ def merge_env_vars(config):
     """Fetch environmental variables related to orion's managerial data.
 
     :type config: :func:`nesteddict`
-
     """
-    newcfg = deepcopy(config)
+    return merge_configs(config, fetch_env_vars())
+
+
+def fetch_env_vars():
+    """Fetch environmental variables related to orion's managerial data."""
+    env_vars = {}
+
     for signif, evars in ENV_VARS.items():
+        env_vars[signif] = {}
+
         for var_name, key, _ in evars:
             value = os.getenv(var_name)
+
             if value is not None:
-                newcfg[signif][key] = value
-    return newcfg
+                env_vars[signif][key] = value
 
-
-def merge_configs(*configs):
-    raise NotImplementedError
+    return env_vars
 
 
 def merge_orion_config(config, dbconfig, cmdconfig, cmdargs):
@@ -191,25 +192,61 @@ def merge_orion_config(config, dbconfig, cmdconfig, cmdargs):
     .. seealso:: Method-specific configurations reside in `/config`
 
     """
-    expconfig = deepcopy(config)
+    return merge_configs(config, dbconfig, cmdconfig, cmdargs)
 
-    for cfg in (dbconfig, cmdconfig):
-        for k, v in cfg.items():
-            if k in ENV_VARS:
-                for vk, vv in v.items():
-                    expconfig[k][vk] = vv
-            elif v is not None:
-                expconfig[k] = v
 
-    for k, v in cmdargs.items():
-        if v is not None:
-            if k == 'metadata':
-                for vk, vv in v.items():
-                    expconfig[k][vk] = vv
-            else:
-                expconfig[k] = v
+def merge_configs(*configs):
+    """Merge configuration dictionnaries following the given hierarchy
 
-    return expconfig
+    Suppose function is called as merge_configs(A, B, C). Then any pair (key, value) in C would
+    overwrite any previous value from A or B. Same apply for B over A.
+
+    If for some pair (key, value), the value is a dictionary, then it will either overwrite previous
+    value if it was not also a directory, or it will be merged following
+    `merge_configs(old_value, new_value)`.
+
+    .. warning:
+
+        Redefinition of subdictionaries may lead to confusing results because merges do not remove
+        data.
+
+        If for instance, we have {'a': {'b': 1, 'c': 2}} and we would like to update `'a'` such that
+        it only have `{'c': 3}`, it won't work with {'a': {'c': 3}}.
+
+        merge_configs({'a': {'b': 1, 'c': 2}}, {'a': {'c': 3}}) -> {'a': {'b': 1, 'c': 3}}
+
+    Example
+    -------
+    .. code-block:: python
+        :linenos:
+
+        a = {'a': 1, 'b': {'c': 2}}
+        b = {'b': {'c': 3}}
+        c = {'b': {'c': {'d': 4}}}
+
+        m = resolve_config.merge_configs(a, b, c)
+
+        assert m == {'a': 1, 'b': {'c': {'d': 4}}}
+
+        a = {'a': 1, 'b': {'c': 2, 'd': 3}}
+        b = {'b': {'c': 4}}
+        c = {'b': {'c': {'e': 5}}}
+
+        m = resolve_config.merge_configs(a, b, c)
+
+        assert m == {'a': 1, 'b': {'c': {'e': 5}, 'd': 3}}
+
+    """
+    merged_config = configs[0]
+
+    for config in configs[1:]:
+        for key, value in config.items():
+            if isinstance(value, dict) and isinstance(merged_config.get(key), dict):
+                merged_config[key] = merge_configs(merged_config[key], value)
+            elif value is not None:
+                merged_config[key] = value
+
+    return merged_config
 
 
 def infer_versioning_metadata(existing_metadata):

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -481,9 +481,9 @@ class ExperimentView(object):
     __slots__ = ('_experiment', )
 
     #                     Attributes
-    valid_attributes = (["_id", "name", "refers", "metadata", "pool_size", "max_trials", "status"] +
+    valid_attributes = (["_id", "name", "refers", "metadata", "pool_size", "max_trials"] +
                         # Properties
-                        ["space", "algorithms", "stats", "configuration"] +
+                        ["id", "is_done", "space", "algorithms", "stats", "configuration"] +
                         # Methods
                         ["fetch_completed_trials"])
 
@@ -502,7 +502,7 @@ class ExperimentView(object):
         """
         self._experiment = Experiment(name)
 
-        if self._experiment.status is None:
+        if self._experiment.id is None:
             raise ValueError("No experiment with given name '%s' for user '%s' inside database, "
                              "no view can be created." %
                              (self._experiment.name, self._experiment.metadata['user']))
@@ -516,21 +516,3 @@ class ExperimentView(object):
             raise AttributeError("Cannot access attribute %s on view-only experiments." % name)
 
         return getattr(self._experiment, name)
-
-    @property
-    def is_done(self):
-        """Return True, if this experiment is considered to be finished.
-
-        Note that call to this property will **not** change the status of the experiment in the
-        database. Only writable :class:`orion.core.worker.experiment.Experiment` would do so.
-
-        .. seealso::
-            :attr:`orion.core.worker.experiment.Experiment.is_done`
-        """
-        query = dict(
-            experiment=self._id,
-            status='completed'
-            )
-        num_completed_trials = self._experiment._db.count('trials', query)
-
-        return num_completed_trials >= self.max_trials or self.algorithms.is_done

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -313,8 +313,7 @@ class Experiment(object):
         # orion_config to set.
         if self._id is None:
             if config['name'] != self.name or \
-                    config['metadata']['user'] != self.metadata['user'] or \
-                    config['metadata']['datetime'] != self.metadata['datetime']:
+                    config['metadata']['user'] != self.metadata['user']:
                 raise ValueError("Configuration given is inconsistent with this Experiment.")
             is_new = True
         else:

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -478,7 +478,7 @@ class ExperimentView(object):
     #                     Attributes
     valid_attributes = (["_id", "name", "refers", "metadata", "pool_size", "max_trials", "status"] +
                         # Properties
-                        ["space", "algorithms", "stats"] +
+                        ["space", "algorithms", "stats", "configuration"] +
                         # Methods
                         ["fetch_completed_trials"])
 

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -194,7 +194,6 @@ class Experiment(object):
         :param score_handle: A way to decide which trial out of the *new* ones to
            to pick as *reserved*, defaults to a random choice.
         :type score_handle: callable
-
         :return: selected `Trial` object, None if could not find any.
         """
         if score_handle is not None and not callable(score_handle):
@@ -246,7 +245,10 @@ class Experiment(object):
         :param trial: Corresponds to a successful evaluation of a particular run.
         :type trial: `Trial`
 
-        .. note:: Change status from *reserved* to *completed*.
+        .. note::
+
+            Change status from *reserved* to *completed*.
+
         """
         trial.end_time = datetime.datetime.utcnow()
         trial.status = 'completed'
@@ -270,8 +272,10 @@ class Experiment(object):
         """Fetch recent completed trials that this `Experiment` instance has not
         yet seen.
 
-        .. note:: It will return only those with `Trial.end_time` after
-           `_last_fetched`, for performance reasons.
+        .. note::
+
+            It will return only those with `Trial.end_time` after `_last_fetched`, for performance
+            reasons.
 
         :return: list of completed `Trial` objects
         """
@@ -301,7 +305,10 @@ class Experiment(object):
         1. Count how many trials have been completed and compare with `max_trials`.
         2. Ask `algorithms` if they consider there is a chance for further improvement.
 
-        .. note:: To be used as a terminating condition in a ``Worker``.
+        .. note::
+
+            To be used as a terminating condition in a ``Worker``.
+
         """
         query = dict(
             experiment=self._id,
@@ -349,9 +356,11 @@ class Experiment(object):
         If `Experiment` was already set and an overwrite is needed, a *fork*
         is advised with a different :attr:`name` for this particular configuration.
 
-        .. note:: Calling this property is necessary for an experiment's
-           initialization process to be considered as done. But it can be called
-           only once.
+        .. note::
+
+            Calling this property is necessary for an experiment's initialization process to be
+            considered as done. But it can be called only once.
+
         """
         if self._init_done:
             raise RuntimeError("Configuration is done; cannot reset an Experiment.")
@@ -513,8 +522,9 @@ class Experiment(object):
             self.refers['adapter'] = Adapter.build(self.refers['adapter'])
 
     def _fork_config(self, config):
-        """Ask for a different identifier for this experiment. Set :attr:`refers`
-        key to previous experiment's name, the one that we forked from.
+        """Ask for a different identifier for this experiment.
+
+        Set :attr:`node` key to previous experiment's name, the one that we forked from.
 
         :param config: Conflicting configuration that will change based on prompt.
         """

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -485,13 +485,12 @@ class ExperimentView(object):
     def __init__(self, name):
         """Initialize viewed experiment object with primary key (:attr:`name`, :attr:`user`).
 
-        Try to find an entry in `Database` with such a key and config this object
-        from it import, if successful. Else, init with default/empty values and
-        insert new entry with this object's attributes in database.
+        Build an experiment from configuration found in `Database` with a key (name, user).
 
         .. note::
 
             A view is fully configured at initialiation. It cannot be reconfigured.
+            If no experiment is found for the key (name, user), a `ValueError` will be raised.
 
         :param name: Describe a configuration with a unique identifier per :attr:`user`.
         :type name: str

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -15,7 +15,7 @@ import getpass
 import logging
 import random
 
-from orion.core.io.database import Database, ReadOnlyDB
+from orion.core.io.database import Database, DuplicateKeyError, ReadOnlyDB
 from orion.core.io.space_builder import SpaceBuilder
 from orion.core.utils.format_trials import trial_to_tuple
 from orion.core.worker.primary_algo import PrimaryAlgo
@@ -301,6 +301,11 @@ class Experiment(object):
         """
         if self._init_done:
             raise RuntimeError("Configuration is done; cannot reset an Experiment.")
+
+        # Experiment was build using db, but config was build before experiment got in db.
+        # Fake a DuplicateKeyError to force reinstantiation of experiment with proper config.
+        if self._id is not None and "datetime" not in config['metadata']:
+            raise DuplicateKeyError("Cannot register an existing experiment with a new config")
 
         # Copy and simulate instantiating given configuration
         experiment = Experiment(self.name)

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -25,6 +25,7 @@ from orion.core.worker.trial import Trial
 log = logging.getLogger(__name__)
 
 
+# pylint: disable=too-many-public-methods
 class Experiment(object):
     """Represents an entry in database/experiments collection.
 
@@ -77,7 +78,7 @@ class Experiment(object):
     """
 
     __slots__ = ('name', 'refers', 'metadata', 'pool_size', 'max_trials',
-                 'algorithms', '_db', '_init_done', '_id', '_last_fetched')
+                 'algorithms', '_db', '_init_done', '_id', '_node', '_last_fetched')
     non_forking_attrs = ('pool_size', 'max_trials')
 
     def __init__(self, name):
@@ -101,6 +102,7 @@ class Experiment(object):
 
         self._id = None
         self.name = name
+        self._node = None
         self.refers = dict()
         user = getpass.getuser()
         self.metadata = {'user': user}
@@ -139,6 +141,52 @@ class Experiment(object):
         self._db.ensure_index('trials', 'start_time')
         self._db.ensure_index('trials', [('end_time', Database.DESCENDING)])
 
+    def fetch_trials(self, query, selection=None):
+        """Fetch trials of the experiment in the database
+
+        .. note::
+
+            The query is always updated with `{"experiment": self._id}`
+
+        .. seealso::
+
+            :meth:`orion.core.io.database.AbstractDB.read` for more information about the
+            arguments.
+
+        """
+        query["experiment"] = self._id
+
+        return Trial.build(self._db.read('trials', query, selection))
+
+    def fetch_trials_tree(self, query, selection=None):
+        """Fetch trials recursively in the EVC tree
+
+        .. seealso::
+
+            :meth:`orion.core.worker.Experiment.fetch_trials` for more information about the
+            arguments.
+
+            :class:`orion.core.evc.experiment.ExperimentNode` for more information about the EVC
+            tree.
+
+        """
+        if self._node is None:
+            return self.fetch_trials(query, selection)
+
+        return self._node.fetch_trials(query, selection)
+
+    def connect_to_version_control_tree(self, node):
+        """Connect the experiment to its node in a version control tree
+
+        .. seealso::
+
+            :class:`orion.core.evc.experiment.ExperimentNode`
+
+        :param node: Node giving access to the experiment version control tree.
+        :type name: None or `ExperimentNode`
+        """
+        self._node = node
+
     def reserve_trial(self, score_handle=None):
         """Find *new* trials that exist currently in database and select one of
         them based on the highest score return from `score_handle` callable.
@@ -156,7 +204,7 @@ class Experiment(object):
             experiment=self._id,
             status={'$in': ['new', 'suspended', 'interrupted']}
             )
-        new_trials = Trial.build(self._db.read('trials', query))
+        new_trials = self.fetch_trials(query)
 
         if not new_trials:
             return None
@@ -232,7 +280,7 @@ class Experiment(object):
             status='completed',
             end_time={'$gte': self._last_fetched}
             )
-        completed_trials = Trial.build(self._db.read('trials', query))
+        completed_trials = self.fetch_trials_tree(query)
         self._last_fetched = datetime.datetime.utcnow()
 
         return completed_trials
@@ -394,19 +442,21 @@ class Experiment(object):
             experiment=self._id,
             status='completed'
             )
-        completed_trials = self._db.read('trials', query,
-                                         selection={'_id': 1, 'end_time': 1,
-                                                    'results': 1})
+        selection = {
+            '_id': 1,
+            'end_time': 1,
+            'results': 1
+            }
+        completed_trials = self.fetch_trials(query, selection)
         stats = dict()
         stats['trials_completed'] = len(completed_trials)
         stats['best_trials_id'] = None
-        trial = Trial(**completed_trials[0])
+        trial = completed_trials[0]
         stats['best_evaluation'] = trial.objective.value
         stats['best_trials_id'] = trial.id
         stats['start_time'] = self.metadata['datetime']
         stats['finish_time'] = stats['start_time']
         for trial in completed_trials:
-            trial = Trial(**trial)
             # All trials are going to finish certainly after the start date
             # of the experiment they belong to
             if trial.end_time > stats['finish_time']:  # pylint:disable=no-member
@@ -491,6 +541,10 @@ class Experiment(object):
 
         return is_diff
 
+    def __repr__(self):
+        """Represent the object as a string."""
+        return "Experiment(name=%s, metadata.user=%s)" % (self.name, self.metadata['user'])
+
 
 # pylint: disable=too-few-public-methods
 class ExperimentView(object):
@@ -509,7 +563,8 @@ class ExperimentView(object):
                         # Properties
                         ["id", "is_done", "space", "algorithms", "stats", "configuration"] +
                         # Methods
-                        ["fetch_completed_trials"])
+                        ["fetch_trials", "fetch_trials_tree", "fetch_completed_trials",
+                         "connect_to_version_control_tree"])
 
     def __init__(self, name):
         """Initialize viewed experiment object with primary key (:attr:`name`, :attr:`user`).
@@ -540,3 +595,7 @@ class ExperimentView(object):
             raise AttributeError("Cannot access attribute %s on view-only experiments." % name)
 
         return getattr(self._experiment, name)
+
+    def __repr__(self):
+        """Represent the object as a string."""
+        return "ExperimentView(name=%s, metadata.user=%s)" % (self.name, self.metadata['user'])

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -491,13 +491,19 @@ class ExperimentView(object):
 
         .. note::
 
-            A view is **note** initializable. It is meant to access trials and statistics from the
-            experiment..
+            A view is fully configured at initialiation. It cannot be reconfigured.
 
         :param name: Describe a configuration with a unique identifier per :attr:`user`.
         :type name: str
         """
         self._experiment = Experiment(name)
+
+        if self._experiment.status is None:
+            raise ValueError("No experiment with given name '%s' for user '%s' inside database, "
+                             "no view can be created." %
+                             (self._experiment.name, self._experiment.metadata['user']))
+
+        self._experiment.configure(self._experiment.configuration)
         self._experiment._db = ReadOnlyDB(self._experiment._db)
 
     def __getattr__(self, name):

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -15,6 +15,7 @@ import getpass
 import logging
 import random
 
+from orion.core.evc.adapters import Adapter, BaseAdapter
 from orion.core.io.database import Database, DuplicateKeyError, ReadOnlyDB
 from orion.core.io.space_builder import SpaceBuilder
 from orion.core.utils.format_trials import trial_to_tuple
@@ -35,15 +36,16 @@ class Experiment(object):
        id of the experiment in the database if experiment is configured. Value is `None`
        if the experiment is not configured.
     refers : dict or list of `Experiment` objects, after initialization is done.
-       A dictionary pointing to a past `Experiment` name, ``refers[name]``, whose
+       A dictionary pointing to a past `Experiment` id, ``refers[parent_id]``, whose
        trials we want to add in the history of completed trials we want to re-use.
+       For convenience and database effiency purpose, all experiments of a common tree shares
+       `refers[root_id]`, with the root experiment refering to itself.
     metadata : dict
        Contains managerial information about this `Experiment`.
     pool_size : int
        How many workers can participate asynchronously in this `Experiment`.
     max_trials : int
        How many trials must be evaluated, before considering this `Experiment` done.
-
        This attribute can be updated if the rest of the experiment configuration
        is the same. In that case, if trying to set to an already set experiment,
        it will overwrite the previous one.
@@ -99,7 +101,7 @@ class Experiment(object):
 
         self._id = None
         self.name = name
-        self.refers = None
+        self.refers = dict()
         user = getpass.getuser()
         self.metadata = {'user': user}
         self.pool_size = None
@@ -284,6 +286,10 @@ class Experiment(object):
                 config[attrname] = attribute.configuration
             else:
                 config[attrname] = attribute
+
+            if self._init_done and attrname == "refers" and attribute.get("adapter"):
+                config[attrname] = copy.deepcopy(config[attrname])
+                config[attrname]['adapter'] = config[attrname]['adapter'].configuration
         # Reason for deepcopy is that some attributes are dictionaries
         # themselves, we don't want to accidentally change the state of this
         # object from a getter.
@@ -342,6 +348,14 @@ class Experiment(object):
             # XXX: Reminder for future DB implementations:
             # MongoDB, updates an inserted dict with _id, so should you :P
             self._id = final_config['_id']
+
+            # Update refers in db if experiment is root
+            if not self.refers:
+                self.refers = {'root_id': self._id, 'parent_id': None, 'adapter': []}
+                update = {'refers': self.refers}
+                query = {'_id': self._id}
+                self._db.write('experiments', data=update, query=query)
+
         else:
             # Writing the final config to an already existing experiment raises
             # a DuplicatKeyError because of the embedding id `metadata.user`.
@@ -409,7 +423,7 @@ class Experiment(object):
         """Check before dispatching experiment whether configuration corresponds
         to a executable experiment environment.
 
-        1. Check `refers` and instantiate `Experiment` objects from it. (TODO)
+        1. Check `refers` and instantiate `Adapter` objects from it.
         2. Try to build parameter space from user arguments.
         3. Check whether configured algorithms correspond to [known]/valid
            implementations of the ``Algorithm`` class. Instantiate these objects.
@@ -426,6 +440,13 @@ class Experiment(object):
                 log.warning("Found section '%s' in configuration. "
                             "Cannot set private attributes. Ignoring.", section)
                 continue
+
+            # Copy sub configuration to value confusing side-effects
+            # Only copy at this level, not `config` directly to avoid TypeErrors if config contains
+            # non-serializable objects (copy.deepcopy complains otherwise).
+            if isinstance(value, dict):
+                value = copy.deepcopy(value)
+
             setattr(self, section, value)
 
         try:
@@ -437,6 +458,9 @@ class Experiment(object):
             self.algorithms = PrimaryAlgo(space, self.algorithms)
         except KeyError:
             pass
+
+        if self.refers and not isinstance(self.refers.get('adapter'), BaseAdapter):
+            self.refers['adapter'] = Adapter.build(self.refers['adapter'])
 
     def _fork_config(self, config):
         """Ask for a different identifier for this experiment. Set :attr:`refers`

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -528,4 +528,4 @@ class ExperimentView(object):
             )
         num_completed_trials = self._experiment._db.count('trials', query)
 
-        return num_completed_trials >= self.max_trials
+        return num_completed_trials >= self.max_trials or self.algorithms.is_done

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -398,6 +398,7 @@ class Experiment(object):
         # If everything is alright, push new config to database
         if is_new:
             final_config['metadata']['datetime'] = datetime.datetime.utcnow()
+            self.metadata['datetime'] = final_config['metadata']['datetime']
             # This will raise DuplicateKeyError if a concurrent experiment with
             # identical (name, metadata.user) is written first in the database.
 

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -132,6 +132,7 @@ class Trial(object):
         function or of an 'constraint' expression.
         """
 
+        __slots__ = ()
         allowed_types = ('objective', 'constraint', 'gradient')
 
     class Param(Value):
@@ -139,6 +140,7 @@ class Trial(object):
         floating precision numerical or a categorical expression (e.g. a string).
         """
 
+        __slots__ = ()
         allowed_types = ('integer', 'real', 'categorical')
 
     __slots__ = ('experiment', '_id', '_status', 'worker',

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -106,6 +106,10 @@ class Trial(object):
                 )
             return ret
 
+        def __eq__(self, other):
+            """Test equality based on self.to_dict()"""
+            return self.name == other.name and self.type == other.type and self.value == other.value
+
         def __str__(self):
             """Represent partially with a string."""
             ret = "{0}(name={1}, type={2}, value={3})".format(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 
 from orion.algo.base import (BaseAlgorithm, OptimizationAlgorithm)
+from orion.core.io import resolve_config
 from orion.core.io.database import Database
 from orion.core.io.database.mongodb import MongoDB
 
@@ -124,3 +125,15 @@ def null_db_instances():
     """Nullify singleton instance so that we can assure independent instantiation tests."""
     Database.instance = None
     MongoDB.instance = None
+
+
+@pytest.fixture
+def version_XYZ(monkeypatch):
+    """Force orion version XYZ on output of resolve_config.fetch_metadata"""
+    non_patched_fetch_metadata = resolve_config.fetch_metadata
+
+    def fetch_metadata(cmdargs):
+        metadata = non_patched_fetch_metadata(cmdargs)
+        metadata['orion_version'] = 'XYZ'
+        return metadata
+    monkeypatch.setattr(resolve_config, "fetch_metadata", fetch_metadata)

--- a/tests/functional/commands/experiment.yaml
+++ b/tests/functional/commands/experiment.yaml
@@ -17,12 +17,9 @@
     user_version: ~
     user_commit_hash: as5f7asf5asfa7sf
   refers:
-    name: 
-    user: tsirif
-    params:
-      - name:
-        type: 
-        value:
+    adapter: [] 
+    root_id: test_insert_normal
+    parent_id: null
   pool_size: 2
   max_trials: 1000
   algorithms:
@@ -40,12 +37,9 @@
     user_version: ~
     user_commit_hash: as5f7asf5asfa7sf
   refers:
-    name: 
-    user: tsirif
-    params:
-      - name:
-        type: 
-        value:
+    adapter: [] 
+    root_id: test_insert_missing_default_value
+    parent_id: null
   pool_size: 2
   max_trials: 1000
   algorithms:
@@ -63,12 +57,9 @@
     user_version: ~
     user_commit_hash: as5f7asf5asfa7sf
   refers:
-    name: 
-    user: tsirif
-    params:
-      - name:
-        type: 
-        value:
+    adapter: [] 
+    root_id: test_insert_two_hyperparameters
+    parent_id: null
   pool_size: 2
   max_trials: 1000
   algorithms: 

--- a/tests/functional/parsing/test_parsing_base.py
+++ b/tests/functional/parsing/test_parsing_base.py
@@ -6,7 +6,7 @@ import os
 
 import pytest
 
-from orion.core.cli import resolve_config
+import orion.core.cli.base as cli
 
 
 def _create_parser(need_subparser=True):
@@ -26,7 +26,7 @@ def test_common_group_arguments(database, monkeypatch):
     parser, subparsers = _create_parser()
     args_list = ["-n", "test", "--config", "./orion_config_random.yaml"]
 
-    resolve_config.get_basic_args_group(parser)
+    cli.get_basic_args_group(parser)
     args = vars(parser.parse_args(args_list))
     assert args['name'] == 'test'
     assert args['config'].name == "./orion_config_random.yaml"
@@ -39,7 +39,7 @@ def test_user_group_arguments(database, monkeypatch):
     parser = _create_parser(False)
     args_list = ["./black_box.py", "-x~normal(50,50)"]
 
-    resolve_config.get_user_args_group(parser)
+    cli.get_user_args_group(parser)
     args = vars(parser.parse_args(args_list))
     assert args['user_script'] == './black_box.py'
     assert len(args['user_args']) == 1
@@ -54,8 +54,8 @@ def test_common_and_user_group_arguments(database, monkeypatch):
     args_list = ["-n", "test", "-c", "./orion_config_random.yaml",
                  "./black_box.py", "-x~normal(50,50)"]
 
-    resolve_config.get_basic_args_group(parser)
-    resolve_config.get_user_args_group(parser)
+    cli.get_basic_args_group(parser)
+    cli.get_user_args_group(parser)
     args = vars(parser.parse_args(args_list))
     assert args['name'] == 'test'
     assert args['config'].name == './orion_config_random.yaml'

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -20,9 +20,13 @@ JSON_SAMPLE = os.path.join(TEST_DIR, 'sample_config.json')
 @pytest.fixture()
 def create_db_instance(null_db_instances, clean_db):
     """Create and save a singleton database instance."""
-    database = Database(of_type='MongoDB', name='orion_test',
-                        username='user', password='pass')
-    return database
+    try:
+        db = Database(of_type='MongoDB', name='orion_test',
+                      username='user', password='pass')
+    except ValueError:
+        db = Database()
+
+    return db
 
 
 @pytest.fixture(scope='session')
@@ -102,30 +106,19 @@ def random_dt(monkeypatch):
 
 
 @pytest.fixture()
-def hacked_exp(with_user_dendi, random_dt, clean_db):
+def hacked_exp(with_user_dendi, random_dt, clean_db, create_db_instance):
     """Return an `Experiment` instance with hacked _id to find trials in
     fake database.
     """
-    try:
-        Database(of_type='MongoDB', name='orion_test',
-                 username='user', password='pass')
-    except (TypeError, ValueError):
-        pass
     exp = Experiment('supernaedo2')
     exp._id = 'supernaedo2'  # white box hack
     return exp
 
 
 @pytest.fixture()
-def trial_id_substitution(with_user_tsirif, random_dt, clean_db):
+def trial_id_substitution(with_user_tsirif, random_dt, clean_db, create_db_instance):
     """Replace trial ids by the actual ids of the experiments."""
-    try:
-        Database(of_type='MongoDB', name='orion_test',
-                 username='user', password='pass')
-    except (TypeError, ValueError):
-        pass
-
-    db = Database()
+    db = create_db_instance
     experiments = db.read('experiments', {'metadata.user': 'tsirif'})
     experiment_dict = dict((experiment['name'], experiment) for experiment in experiments)
     trials = db.read('trials')

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -114,3 +114,23 @@ def hacked_exp(with_user_dendi, random_dt, clean_db):
     exp = Experiment('supernaedo2')
     exp._id = 'supernaedo2'  # white box hack
     return exp
+
+
+@pytest.fixture()
+def trial_id_substitution(with_user_tsirif, random_dt, clean_db):
+    """Replace trial ids by the actual ids of the experiments."""
+    try:
+        Database(of_type='MongoDB', name='orion_test',
+                 username='user', password='pass')
+    except (TypeError, ValueError):
+        pass
+
+    db = Database()
+    experiments = db.read('experiments', {'metadata.user': 'tsirif'})
+    experiment_dict = dict((experiment['name'], experiment) for experiment in experiments)
+    trials = db.read('trials')
+
+    for trial in trials:
+        query = {'experiment': trial['experiment']}
+        update = {'experiment': experiment_dict[trial['experiment']]['_id']}
+        db.write('trials', update, query)

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -127,3 +127,24 @@ def trial_id_substitution(with_user_tsirif, random_dt, clean_db, create_db_insta
         query = {'experiment': trial['experiment']}
         update = {'experiment': experiment_dict[trial['experiment']]['_id']}
         db.write('trials', update, query)
+
+
+@pytest.fixture()
+def refers_id_substitution(with_user_tsirif, random_dt, clean_db, create_db_instance):
+    """Replace trial ids by the actual ids of the experiments."""
+    db = create_db_instance
+    query = {'metadata.user': 'tsirif'}
+    selection = {'name': 1, 'refers': 1}
+    experiments = db.read('experiments', query, selection)
+    experiment_dict = dict((experiment['name'], experiment) for experiment in experiments)
+
+    for experiment in experiments:
+        query = {'_id': experiment['_id']}
+        print(experiment['refers'])
+        root_id = experiment_dict[experiment['refers']['root_id']]['_id']
+        if experiment['refers']['parent_id'] is not None:
+            parent_id = experiment_dict[experiment['refers']['parent_id']]['_id']
+        else:
+            parent_id = None
+        update = {'refers.root_id': root_id, 'refers.parent_id': parent_id}
+        db.write('experiments', update, query)

--- a/tests/unittests/core/database_test.py
+++ b/tests/unittests/core/database_test.py
@@ -48,7 +48,7 @@ class TestDatabaseFactory(object):
         assert 'singleton' in str(exc_info.value)
 
 
-@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("null_db_instances", "clean_db")
 class TestReadOnlyDatabase(object):
     """Test coherence of read-only database and its wrapped database."""
 

--- a/tests/unittests/core/database_test.py
+++ b/tests/unittests/core/database_test.py
@@ -52,11 +52,9 @@ class TestDatabaseFactory(object):
 class TestReadOnlyDatabase(object):
     """Test coherence of read-only database and its wrapped database."""
 
-    def test_valid_attributes(self):
+    def test_valid_attributes(self, create_db_instance):
         """Test attributes are coherent from view and wrapped database."""
-        database = Database(of_type='MongoDB', name='orion_test',
-                            username='user', password='pass')
-
+        database = create_db_instance
         readonly_database = ReadOnlyDB(database)
 
         assert readonly_database.is_connected == database.is_connected
@@ -65,11 +63,9 @@ class TestReadOnlyDatabase(object):
         assert readonly_database.username == database.username
         assert readonly_database.password == database.password
 
-    def test_read(self):
+    def test_read(self, create_db_instance):
         """Test read is coherent from view and wrapped database."""
-        database = Database(of_type='MongoDB', name='orion_test',
-                            username='user', password='pass')
-
+        database = create_db_instance
         readonly_database = ReadOnlyDB(database)
 
         args = {"collection_name": "trials", "query": {"experiment": "supernaedo2"}}
@@ -79,11 +75,9 @@ class TestReadOnlyDatabase(object):
         assert len(result) > 0  # Otherwise the test is pointless
         assert readonly_result == result
 
-    def test_invalid_attributes(self):
+    def test_invalid_attributes(self, create_db_instance):
         """Test that attributes for writing are not accessible."""
-        database = Database(of_type='MongoDB', name='orion_test',
-                            username='user', password='pass')
-
+        database = create_db_instance
         readonly_database = ReadOnlyDB(database)
 
         # Test that database.ensure_index indeed exists

--- a/tests/unittests/core/evc/test_adapters.py
+++ b/tests/unittests/core/evc/test_adapters.py
@@ -1,0 +1,806 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Collection of tests for :mod:`orion.core.evc.adapters`."""
+
+import pytest
+
+from orion.algo.space import Real
+from orion.core.evc.adapters import (
+    Adapter, AlgorithmChange, CodeChange, CompositeAdapter, DimensionAddition, DimensionDeletion,
+    DimensionPriorChange, DimensionRenaming)
+from orion.core.io.space_builder import DimensionBuilder
+from orion.core.worker.trial import Trial
+
+
+@pytest.fixture
+def dummy_param():
+    """Give dummy param integer param with value 1"""
+    return Trial.Param(name='dummy', type='integer', value=1)
+
+
+@pytest.fixture
+def small_prior():
+    """Give string format of small uniform distribution prior"""
+    return "uniform(0, 10)"
+
+
+@pytest.fixture
+def large_prior():
+    """Give string format of large uniform distribution prior"""
+    return "uniform(0, 1000)"
+
+
+@pytest.fixture
+def normal_prior():
+    """Give string format of normal distribution prior"""
+    return "normal(0, 1)"
+
+
+@pytest.fixture
+def disjoint_prior():
+    """Give string format of uniform distribution disjoint from small and large one"""
+    return "uniform(-20, -10)"
+
+
+@pytest.fixture
+def integer_prior():
+    """Give string format of uniform distribution casted to integers"""
+    return "uniform(-20, -10, discrete=True)"
+
+
+@pytest.fixture
+def categorical_prior():
+    """Give string format of categorical prior with floats, integers and strings"""
+    return "choices([0.1, 1, 2, 'string'])"
+
+
+@pytest.fixture
+def multidim_prior():
+    """Give string format of real distribution with multiple dimensions"""
+    return "uniform(0, 10, shape=(2, 2))"
+
+
+@pytest.fixture
+def trials(small_prior, large_prior, normal_prior, disjoint_prior,
+           integer_prior, categorical_prior, multidim_prior):
+    """Trials with dimensions for all priors defined as fixtures"""
+    N_TRIALS = 10
+
+    priors = dict((name, prior) for (name, prior) in locals().items()
+                  if isinstance(name, str) and name.endswith("_prior"))
+
+    trials = []
+    for _ in range(N_TRIALS):
+        params = []
+        for name, prior in priors.items():
+            dimension = DimensionBuilder().build(name, prior)
+            value = dimension.sample()[0]
+            params.append(Trial.Param(name=name, type=dimension.type, value=value).to_dict())
+        trials.append(Trial(params=params))
+
+    return trials
+
+
+class TestDimensionAdditionInit(object):
+    """Test initialization of :class:`orion.core.evc.adapters.DimensionAddition`"""
+
+    def test_dimension_addition_init_with_param(self, dummy_param):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionAddition`
+        with valid param
+        """
+        dimension_addition_adapter = DimensionAddition(dummy_param)
+
+        assert dimension_addition_adapter.param is dummy_param
+
+    def test_dimension_addition_init_with_bad_param(self):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionAddition`
+        with object which is not a param or a dictionary definition of it
+        """
+        with pytest.raises(TypeError) as exc_info:
+            DimensionAddition('bad')
+
+        assert "Invalid param argument type ('<class 'str'>')." in str(exc_info.value)
+
+    def test_dimension_addition_init_with_dict(self, dummy_param):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionAddition`
+        with a dictionary definition of a param
+        """
+        DimensionAddition(dummy_param.to_dict())
+
+    def test_dimension_addition_init_with_bad_dict(self):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionAddition`
+        with a dictionary which is a bad definition of a param
+        """
+        with pytest.raises(AttributeError) as exc_info:
+            DimensionAddition({'bad': 'dict'})
+
+        assert "'Param' object has no attribute 'bad'" in str(exc_info.value)
+
+
+class TestDimensionDeletionInit(object):
+    """Test initialization of :class:`orion.core.evc.adapters.DimensionDeletion`"""
+
+    def test_dimension_deletion_init_with_param(self, dummy_param):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionDeletion`
+        with valid param
+        """
+        dimension_deletion_adapter = DimensionDeletion(dummy_param)
+
+        assert dimension_deletion_adapter.param is dummy_param
+
+    def test_dimension_deletion_init_with_bad_param(self):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionDeletion`
+        with object which is not a param or a dictionary definition of it
+        """
+        with pytest.raises(TypeError) as exc_info:
+            DimensionDeletion('bad')
+
+        assert "Invalid param argument type ('<class 'str'>')." in str(exc_info.value)
+
+    def test_dimension_deletion_init_with_dict(self, dummy_param):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionDeletion`
+        with a dictionary definition of a param
+        """
+        DimensionDeletion(dummy_param.to_dict())
+
+    def test_dimension_deletion_init_with_bad_dict(self):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionDeletion`
+        with a dictionary which is a bad definition of a param
+        """
+        with pytest.raises(AttributeError) as exc_info:
+            print(DimensionDeletion({'bad': 'dict'}).param)
+
+        assert "'Param' object has no attribute 'bad'" in str(exc_info.value)
+
+
+class TestDimensionPriorChangeInit(object):
+    """Test initialization of :class:`orion.core.evc.adapters.DimensionPriorChange`"""
+
+    def test_dimension_prior_change_init_with_dimensions(self, large_prior, small_prior):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionPriorChange`
+        with valid string definitions of dimension prior
+        """
+        dimension_prior_change = DimensionPriorChange('dummy', large_prior, small_prior)
+
+        assert dimension_prior_change.old_prior == large_prior
+        assert dimension_prior_change.new_prior == small_prior
+        assert isinstance(dimension_prior_change.old_dimension, Real)
+        assert isinstance(dimension_prior_change.new_dimension, Real)
+
+        assert dimension_prior_change.old_dimension.interval() == (0, 1000)
+        assert dimension_prior_change.new_dimension.interval() == (0, 10)
+
+    def test_dimension_prior_change_init_with_bad_dimensions(self):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionPriorChange`
+        with non valid string definitions of dimension prior
+        """
+        with pytest.raises(TypeError) as exc_info:
+            DimensionPriorChange('dummy', 'bad', 'priors')
+
+        assert "Parameter 'old': Please provide a valid form for prior" in str(exc_info.value)
+
+
+class TestDimensionRenamingInit(object):
+    """Test initialization of :class:`orion.core.evc.adapters.DimensionRenaming`"""
+
+    def test_dimension_renaming_init(self):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionRenaming`
+        with valid names
+        """
+        dimension_renaming = DimensionRenaming('old_name', 'new_name')
+        assert dimension_renaming.old_name == 'old_name'
+        assert dimension_renaming.new_name == 'new_name'
+
+    def test_dimension_renaming_init_bad_name(self):
+        """Test initialization of :class:`orion.core.evc.adapters.DimensionRenaming`
+        with invalid names which are not strings
+        """
+        with pytest.raises(TypeError) as exc_info:
+            DimensionRenaming({'bad': 'name'}, None)
+
+        assert "" in str(exc_info.value)
+
+
+class TestAlgorithmChangeInit(object):
+    """Test initialization of :class:`orion.core.evc.adapters.AlgorithmChange`"""
+
+    def test_algorithm_change_init(self):
+        """Test initialization of :class:`orion.core.evc.adapters.AlgorithmChange`"""
+        AlgorithmChange()
+
+
+class TestCodeChangeInit(object):
+    """Test initialization of :class:`orion.core.evc.adapters.CodeChange`"""
+
+    def test_code_change_init(self):
+        """Test initialization of :class:`orion.core.evc.adapters.CodeChange`
+        with valid change types
+        """
+        code_change_adapter = CodeChange(CodeChange.NOEFFECT)
+        assert code_change_adapter.change_type == CodeChange.NOEFFECT
+
+        code_change_adapter = CodeChange(CodeChange.BREAK)
+        assert code_change_adapter.change_type == CodeChange.BREAK
+
+    def test_code_change_init_bad_type(self):
+        """Test initialization of :class:`orion.core.evc.adapters.CodeChange`
+        with invalid change types
+        """
+        with pytest.raises(ValueError) as exc_info:
+            CodeChange('bad type')
+
+        assert "Invalid code change type 'bad type'" in str(exc_info.value)
+
+
+class TestCompositeAdapterInit(object):
+    """Test initialization of :class:`orion.core.evc.adapters.CompositeAdapter`"""
+
+    def test_composite_adapter_init_emtpy(self):
+        """Test initialization of :class:`orion.core.evc.adapters.CompositeAdapter`
+        with no adapters
+        """
+        composite_adapter = CompositeAdapter()
+        assert len(composite_adapter.adapters) == 0
+
+    def test_composite_adapter_init_with_adapters(self, dummy_param):
+        """Test initialization of :class:`orion.core.evc.adapters.CompositeAdapter`
+        with valid adapters
+        """
+        dimension_addition = DimensionAddition(dummy_param)
+        dimension_deletion = DimensionDeletion(dummy_param)
+        composite_adapter = CompositeAdapter(dimension_addition, dimension_deletion)
+        assert len(composite_adapter.adapters) == 2
+        assert isinstance(composite_adapter.adapters[0], DimensionAddition)
+        assert isinstance(composite_adapter.adapters[1], DimensionDeletion)
+
+    def test_composite_adapter_init_with_bad_adapters(self):
+        """Test initialization of :class:`orion.core.evc.adapters.CompositeAdapter`
+        with invalid adapters
+        """
+        with pytest.raises(TypeError) as exc_info:
+            CompositeAdapter('bad', 'adapters')
+
+        assert ("Provided adapters must be adapter objects, not '<class 'str'>" in
+                str(exc_info.value))
+
+
+def test_adapter_creation(dummy_param):
+    """Test initialization using :meth:`orion.core.evc.adapters.Adapter.build`"""
+    adapter = Adapter.build([{
+        'of_type': 'DimensionAddition',
+        'param': dummy_param.to_dict()}])
+
+    assert isinstance(adapter, CompositeAdapter)
+    assert len(adapter.adapters) == 1
+    assert isinstance(adapter.adapters[0], DimensionAddition)
+    assert adapter.adapters[0].param.to_dict() == dummy_param.to_dict()
+
+
+class TestDimensionAdditionForwardBackward(object):
+    """Test :meth:`orion.core.evc.adapters.DimensionAddition.forward` and
+    :meth:`orion.core.evc.adapters.DimensionAddition.backward`
+    """
+
+    def test_dimension_addition_forward(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionAddition.forward`
+        with valid param and trials
+        """
+        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        dimension_addition_adapter = DimensionAddition(new_param)
+
+        adapted_trials = dimension_addition_adapter.forward(trials)
+
+        assert adapted_trials[0].params[-1] == new_param
+        assert adapted_trials[4].params[-1] == new_param
+        assert adapted_trials[-1].params[-1] == new_param
+
+    def test_dimension_addition_forward_already_existing(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionAddition.forward`
+        with valid param and incompatible trials because param already exists
+        """
+        new_param = Trial.Param(name='normal_prior', type='integer', value=1)
+        dimension_addition_adapter = DimensionAddition(new_param)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            dimension_addition_adapter.forward(trials)
+        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+
+    def test_dimension_addition_backward(self, dummy_param, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionAddition.backward`
+        with valid param and valid trials
+        """
+        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        dimension_addition_adapter = DimensionAddition(new_param)
+
+        sampler = DimensionBuilder().build('random', 'uniform(10, 100, discrete=True)')
+        for trial in trials:
+            random_param = new_param.to_dict()
+            random_param['value'] = sampler.sample()
+            trial.params.append(Trial.Param(**random_param))
+
+        adapted_trials = dimension_addition_adapter.backward(trials)
+        assert len(adapted_trials) == 0
+
+        trials[0].params[-1].value = 1
+        assert trials[0].params[-1] == new_param
+
+        adapted_trials = dimension_addition_adapter.backward(trials)
+        assert len(adapted_trials) == 1
+
+        trials[4].params[-1].value = 1
+        assert trials[4].params[-1] == new_param
+
+        adapted_trials = dimension_addition_adapter.backward(trials)
+        assert len(adapted_trials) == 2
+
+        trials[-1].params[-1].value = 1
+        assert trials[-1].params[-1] == new_param
+
+        adapted_trials = dimension_addition_adapter.backward(trials)
+        assert len(adapted_trials) == 3
+
+        assert new_param not in (adapted_trials[0].params)
+        assert new_param not in (adapted_trials[1].params)
+        assert new_param not in (adapted_trials[2].params)
+
+    def test_dimension_addition_backward_not_existing(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionAddition.backward`
+        with valid param and invalid trials because param does not exist
+        """
+        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        dimension_addition_adapter = DimensionAddition(new_param)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            dimension_addition_adapter.backward(trials)
+        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+
+
+class TestDimensionDeletionForwardBackward(object):
+    """Test :meth:`orion.core.evc.adapters.DimensionDeletion.forward` and
+    :meth:`orion.core.evc.adapters.DimensionDeletion.backward`
+    """
+
+    def test_dimension_deletion_forward(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionDeletion.forward`
+        with valid param and valid trials
+        """
+        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        dimension_deletion_adapter = DimensionDeletion(new_param)
+
+        sampler = DimensionBuilder().build('random', 'uniform(10, 100, discrete=True)')
+        for trial in trials:
+            random_param = new_param.to_dict()
+            random_param['value'] = sampler.sample()
+            trial.params.append(Trial.Param(**random_param))
+
+        adapted_trials = dimension_deletion_adapter.forward(trials)
+        assert len(adapted_trials) == 0
+
+        trials[0].params[-1].value = 1
+        assert trials[0].params[-1] == new_param
+
+        adapted_trials = dimension_deletion_adapter.forward(trials)
+        assert len(adapted_trials) == 1
+
+        trials[4].params[-1].value = 1
+        assert trials[4].params[-1] == new_param
+
+        adapted_trials = dimension_deletion_adapter.forward(trials)
+        assert len(adapted_trials) == 2
+
+        trials[-1].params[-1].value = 1
+        assert trials[-1].params[-1] == new_param
+
+        adapted_trials = dimension_deletion_adapter.forward(trials)
+        assert len(adapted_trials) == 3
+
+        assert new_param not in (adapted_trials[0].params)
+        assert new_param not in (adapted_trials[1].params)
+        assert new_param not in (adapted_trials[2].params)
+
+    def test_dimension_deletion_forward_not_existing(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionDeletion.forward`
+        with valid param and invalid trials because param does not exist
+        """
+        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        dimension_deletion_adapter = DimensionDeletion(new_param)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            dimension_deletion_adapter.forward(trials)
+        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+
+    def test_dimension_deletion_backward(self, dummy_param, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionDeletion.backward`
+        with valid param and valid trials
+        """
+        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+        dimension_deletion_adapter = DimensionDeletion(new_param)
+
+        adapted_trials = dimension_deletion_adapter.backward(trials)
+
+        assert adapted_trials[0].params[-1] == new_param
+        assert adapted_trials[4].params[-1] == new_param
+        assert adapted_trials[-1].params[-1] == new_param
+
+    def test_dimension_deletion_backward_already_existing(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionDeletion.backward`
+        with valid param and invalid trials because param already exist
+        """
+        new_param = Trial.Param(name='normal_prior', type='integer', value=1)
+        dimension_deletion_adapter = DimensionDeletion(new_param)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            dimension_deletion_adapter.backward(trials)
+        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+
+
+class TestDimensionPriorChangeForwardBackward(object):
+    """Test :meth:`orion.core.evc.adapters.DimensionPriorChange.forward` and
+    :meth:`orion.core.evc.adapters.DimensionPriorChange.backward`
+    """
+
+    def test_dimension_prior_change_forward(self, large_prior, small_prior, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionPriorChange.forward`
+        with compatible priors
+        """
+        dimension_prior_change_adapter = DimensionPriorChange(
+            'small_prior', small_prior, large_prior)
+
+        adapted_trials = dimension_prior_change_adapter.forward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+    def test_dimension_prior_change_forward_incompatible_dimensions(
+            self, small_prior, disjoint_prior, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionPriorChange.forward`
+        with incompatible priors, such that all trials are filtered out
+        """
+        dimension_prior_change_adapter = DimensionPriorChange(
+            'small_prior', small_prior, disjoint_prior)
+
+        adapted_trials = dimension_prior_change_adapter.forward(trials)
+
+        assert len(adapted_trials) == 0
+
+    def test_dimension_prior_change_backward(self, large_prior, small_prior, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionPriorChange.backward`
+        with compatible priors
+        """
+        dimension_prior_change_adapter = DimensionPriorChange(
+            'large_prior', large_prior, small_prior)
+
+        adapted_trials = dimension_prior_change_adapter.backward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+    def test_dimension_prior_change_backward_incompatible_dimensions(
+            self, disjoint_prior, small_prior, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionPriorChange.backward`
+        with incompatible priors, such that all trials are filtered out
+        """
+        dimension_prior_change_adapter = DimensionPriorChange(
+            'small_prior', disjoint_prior, small_prior)
+
+        adapted_trials = dimension_prior_change_adapter.backward(trials)
+
+        assert len(adapted_trials) == 0
+
+
+class TestDimensionRenamingForwardBackward(object):
+    """Test :meth:`orion.core.evc.adapters.DimensionRenaming.forward` and
+    :meth:`orion.core.evc.adapters.DimensionRenaming.backward`
+    """
+
+    def test_dimension_renaming_forward(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionRenaming.forward`
+        with valid names
+        """
+        old_name = 'small_prior'
+        new_name = 'new_name'
+
+        dimension_renaming_adapter = DimensionRenaming(old_name, new_name)
+
+        adapted_trials = dimension_renaming_adapter.forward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert new_name in [param.name for param in adapted_trials[0].params]
+        assert old_name not in [param.name for param in adapted_trials[0].params]
+
+        assert new_name in [param.name for param in adapted_trials[-1].params]
+        assert old_name not in [param.name for param in adapted_trials[-1].params]
+
+    def test_dimension_renaming_forward_incompatible(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionRenaming.forward`
+        with non existing old name in trials
+        """
+        old_name = 'bad name'
+        new_name = 'small_prior'
+
+        dimension_renaming_adapter = DimensionRenaming(old_name, new_name)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            dimension_renaming_adapter.forward(trials)
+        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+
+    def test_dimension_renaming_backward(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionRenaming.backward`
+        with valid names
+        """
+        old_name = 'old_name'
+        new_name = 'small_prior'
+
+        dimension_renaming_adapter = DimensionRenaming(old_name, new_name)
+
+        adapted_trials = dimension_renaming_adapter.backward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert old_name in [param.name for param in adapted_trials[0].params]
+        assert new_name not in [param.name for param in adapted_trials[0].params]
+
+        assert old_name in [param.name for param in adapted_trials[-1].params]
+        assert new_name not in [param.name for param in adapted_trials[-1].params]
+
+    def test_dimension_renaming_backward_incompatible(self, trials):
+        """Test :meth:`orion.core.evc.adapters.DimensionRenaming.backward`
+        with non existing new name in trials
+        """
+        old_name = 'small_prior'
+        new_name = 'bad name'
+
+        dimension_renaming_adapter = DimensionRenaming(old_name, new_name)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            dimension_renaming_adapter.backward(trials)
+        assert "Provided trial does not have a compatible configuration" in str(exc_info.value)
+
+
+class TestAlgorithmChangeForwardBackward(object):
+    """Test :meth:`orion.core.evc.adapters.AlgorithmChange.forward` and
+    :meth:`orion.core.evc.adapters.AlgorithmChange.backward`
+    """
+
+    def test_algorithm_change_forward(self, trials):
+        """Test :meth:`orion.core.evc.adapters.AlgorithmChange.forward`"""
+        algorithm_change_adaptor = AlgorithmChange()
+
+        adapted_trials = algorithm_change_adaptor.forward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert adapted_trials[0] is trials[0]
+        assert adapted_trials[-1] is trials[-1]
+
+    def test_algorithm_change_backward(self, trials):
+        """Test :meth:`orion.core.evc.adapters.AlgorithmChange.backward`"""
+        algorithm_change_adaptor = AlgorithmChange()
+
+        adapted_trials = algorithm_change_adaptor.backward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert adapted_trials[0] is trials[0]
+        assert adapted_trials[-1] is trials[-1]
+
+
+class TestCodeChangeForwardBackward(object):
+    """Test :meth:`orion.core.evc.adapters.CodeChange.forward` and
+    :meth:`orion.core.evc.adapters.CodeChange.backward`
+    """
+
+    def test_code_change_forward_noeffect(self, trials):
+        """Test :meth:`orion.core.evc.adapters.CodeChange.forward` with change type NOEFFECT"""
+        code_change_adapter = CodeChange(CodeChange.NOEFFECT)
+
+        adapted_trials = code_change_adapter.forward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert adapted_trials[0] is trials[0]
+        assert adapted_trials[-1] is trials[-1]
+
+    def test_code_change_forward_unsure(self, trials):
+        """Test :meth:`orion.core.evc.adapters.CodeChange.forward` with change type UNSURE"""
+        code_change_adapter = CodeChange(CodeChange.UNSURE)
+
+        adapted_trials = code_change_adapter.forward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert adapted_trials[0] is trials[0]
+        assert adapted_trials[-1] is trials[-1]
+
+    def test_code_change_forward_break(self, trials):
+        """Test :meth:`orion.core.evc.adapters.CodeChange.forward` with change type BREAK"""
+        code_change_adapter = CodeChange(CodeChange.BREAK)
+
+        adapted_trials = code_change_adapter.forward(trials)
+
+        assert len(adapted_trials) == 0
+
+    def test_code_change_backward_noeffect(self, trials):
+        """Test :meth:`orion.core.evc.adapters.CodeChange.backward` with change type NOEFFECT"""
+        code_change_adapter = CodeChange(CodeChange.NOEFFECT)
+
+        adapted_trials = code_change_adapter.backward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert adapted_trials[0] is trials[0]
+        assert adapted_trials[-1] is trials[-1]
+
+    def test_code_change_backward_unsure(self, trials):
+        """Test :meth:`orion.core.evc.adapters.CodeChange.backward` with change type UNSURE"""
+        code_change_adapter = CodeChange(CodeChange.UNSURE)
+
+        adapted_trials = code_change_adapter.backward(trials)
+
+        assert len(adapted_trials) == 0
+
+    def test_code_change_backward_break(self, trials):
+        """Test :meth:`orion.core.evc.adapters.CodeChange.backward` with change type BREAK"""
+        code_change_adapter = CodeChange(CodeChange.BREAK)
+
+        adapted_trials = code_change_adapter.backward(trials)
+
+        assert len(adapted_trials) == 0
+
+
+class TestCompositeAdapterForwardBackward(object):
+    """Test :meth:`orion.core.evc.adapters.CompositeAdapter.forward` and
+    :meth:`orion.core.evc.adapters.CompositeAdapter.backward`
+    """
+
+    def test_composite_adapter_forward_emtpy(self, trials):
+        """Test :meth:`orion.core.evc.adapters.CompositeAdapter.forward` and
+        :meth:`orion.core.evc.adapters.CompositeAdapter.backward` with no adapters
+        """
+        composite_adapter = CompositeAdapter()
+
+        assert len(composite_adapter.forward(trials)) == len(trials)
+        assert len(composite_adapter.backward(trials)) == len(trials)
+
+    def test_composite_adapter_forward(self, dummy_param, trials):
+        """Test :meth:`orion.core.evc.adapters.CompositeAdapter.forward` with two adapters"""
+        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+
+        dimension_addition_adapter = DimensionAddition(new_param)
+        dimension_deletion_adapter = DimensionDeletion(new_param)
+
+        composite_adapter = CompositeAdapter(dimension_addition_adapter)
+
+        adapted_trials = composite_adapter.forward(trials)
+
+        assert adapted_trials[0].params[-1] == new_param
+        assert adapted_trials[4].params[-1] == new_param
+        assert adapted_trials[-1].params[-1] == new_param
+
+        composite_adapter = CompositeAdapter(dimension_addition_adapter, dimension_deletion_adapter)
+
+        adapted_trials = composite_adapter.forward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert new_param not in (adapted_trials[0].params)
+        assert new_param not in (adapted_trials[4].params)
+        assert new_param not in (adapted_trials[-1].params)
+
+    def test_composite_adapter_backward(self, dummy_param, trials):
+        """Test :meth:`orion.core.evc.adapters.CompositeAdapter.backward` with two adapters"""
+        new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+
+        dimension_addition_adapter = DimensionAddition(new_param)
+        dimension_deletion_adapter = DimensionDeletion(new_param)
+
+        composite_adapter = CompositeAdapter(dimension_deletion_adapter)
+
+        adapted_trials = composite_adapter.backward(trials)
+
+        assert adapted_trials[0].params[-1] == new_param
+        assert adapted_trials[4].params[-1] == new_param
+        assert adapted_trials[-1].params[-1] == new_param
+
+        composite_adapter = CompositeAdapter(dimension_addition_adapter, dimension_deletion_adapter)
+
+        adapted_trials = composite_adapter.backward(trials)
+
+        assert len(adapted_trials) == len(trials)
+
+        assert new_param not in (adapted_trials[0].params)
+        assert new_param not in (adapted_trials[4].params)
+        assert new_param not in (adapted_trials[-1].params)
+
+
+def test_dimension_addition_configuration(dummy_param):
+    """Test :meth:`orion.core.evc.adapters.DimensionAddition.configuration`"""
+    dimension_addition_adapter = DimensionAddition(dummy_param)
+
+    configuration = dimension_addition_adapter.configuration[0]
+
+    assert configuration['of_type'] == "dimensionaddition"
+    assert configuration['param'] == dummy_param.to_dict()
+
+    assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
+
+
+def test_dimension_deletion_configuration(dummy_param):
+    """Test :meth:`orion.core.evc.adapters.DimensionDeletion.configuration`"""
+    dimension_deletion_adapter = DimensionDeletion(dummy_param)
+
+    configuration = dimension_deletion_adapter.configuration[0]
+
+    assert configuration['of_type'] == "dimensiondeletion"
+    assert configuration['param'] == dummy_param.to_dict()
+
+    assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
+
+
+def test_dimension_prior_change_configuration(small_prior, large_prior):
+    """Test :meth:`orion.core.evc.adapters.DimensionPriorChange.configuration`"""
+    dimension_name = 'small_prior'
+    dimension_prior_change_adapter = DimensionPriorChange(dimension_name, small_prior, large_prior)
+
+    configuration = dimension_prior_change_adapter.configuration[0]
+
+    assert configuration['of_type'] == "dimensionpriorchange"
+    assert configuration['name'] == dimension_name
+    assert configuration['old_prior'] == small_prior
+    assert configuration['new_prior'] == large_prior
+
+    assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
+
+
+def test_dimension_renaming_configuration():
+    """Test :meth:`orion.core.evc.adapters.DimensionRenaming.configuration`"""
+    old_name = 'old_name'
+    new_name = 'new_name'
+    dimension_renaming_adapter = DimensionRenaming(old_name, new_name)
+
+    configuration = dimension_renaming_adapter.configuration[0]
+
+    assert configuration['of_type'] == "dimensionrenaming"
+    assert configuration['old_name'] == old_name
+    assert configuration['new_name'] == new_name
+
+    assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
+
+
+def test_algorithm_change_configuration():
+    """Test :meth:`orion.core.evc.adapters.AlgorithmChange.configuration`"""
+    algorithm_change_adaptor = AlgorithmChange()
+
+    configuration = algorithm_change_adaptor.configuration[0]
+
+    assert configuration['of_type'] == "algorithmchange"
+
+    assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
+
+
+def test_code_change_configuration():
+    """Test :meth:`orion.core.evc.adapters.CodeChange.configuration`"""
+    code_change_adaptor = CodeChange(CodeChange.UNSURE)
+
+    configuration = code_change_adaptor.configuration[0]
+
+    assert configuration['of_type'] == "codechange"
+    assert configuration['change_type'] == CodeChange.UNSURE
+
+    assert Adapter.build([configuration]).adapters[0].configuration[0] == configuration
+
+
+def test_composite_configuration(dummy_param):
+    """Test :meth:`orion.core.evc.adapters.CompositeAdapter.configuration`"""
+    new_param = Trial.Param(name='second_normal_prior', type='integer', value=1)
+    dimension_addition_adapter = DimensionAddition(dummy_param)
+    dimension_deletion_adapter = DimensionDeletion(new_param)
+
+    composite_adapter = CompositeAdapter(dimension_addition_adapter, dimension_deletion_adapter)
+
+    configuration = composite_adapter.configuration
+
+    assert configuration[0] == dimension_addition_adapter.configuration[0]
+    assert configuration[1] == dimension_deletion_adapter.configuration[0]
+
+    assert Adapter.build(configuration).adapters[0].configuration[0] == configuration[0]
+    assert Adapter.build(configuration).adapters[1].configuration[0] == configuration[1]

--- a/tests/unittests/core/evc/test_experiment_tree.py
+++ b/tests/unittests/core/evc/test_experiment_tree.py
@@ -1,0 +1,705 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Collection of tests for :mod:`orion.core.evc.experiment`."""
+
+import pytest
+
+from orion.core.evc.adapters import Adapter, CodeChange
+from orion.core.io.evc_builder import build_trimmed_tree
+from orion.core.worker.experiment import ExperimentView
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_parent_fetch_trials(create_db_instance):
+    """Test that experiment fetch trials from parent properly (adapters are muted)"""
+    experiment_name = 'supernaedo2.3'
+    root_name = 'supernaedo2'
+    leaf_names = ['supernaedo2.3']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.parent.item.name == root_name
+    assert len(exp_node.children) == 0
+    # 2
+    # |
+    # 2.3
+    assert len(list(exp_node.root)) == 2
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    for node in exp_node.root:
+        node.item._experiment.refers['adapter'] = Adapter.build([])
+
+    query = {'status': 'completed'}
+    assert len(experiment.fetch_trials(query)) == 4
+    assert len(experiment._experiment._node.parent.item.fetch_trials(query)) == 6
+    assert len(experiment.fetch_trials_tree(query)) == 10
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_children_fetch_trials(create_db_instance):
+    """Test that experiment fetch trials from children properly (adapters are muted)"""
+    experiment_name = 'supernaedo2'
+    root_name = 'supernaedo2'
+    leaf_names = ['supernaedo2.3']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.children[0].item.name == leaf_names[0]
+    assert len(exp_node.children) == 1
+    # 2
+    # |
+    # 2.3
+    assert len(list(exp_node.root)) == 2
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    for node in exp_node.root:
+        node.item._experiment.refers['adapter'] = Adapter.build([])
+
+    query = {'status': 'completed'}
+    assert len(experiment.fetch_trials(query)) == 6
+    assert len(experiment._experiment._node.children[0].item.fetch_trials(query)) == 4
+    assert len(experiment.fetch_trials_tree(query)) == 10
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_parent_parent_fetch_trials(create_db_instance):
+    """Test that experiment fetch trials from grand parent properly (adapters are muted)"""
+    experiment_name = 'supernaedo2.3.1'
+    root_name = 'supernaedo2'
+    leaf_names = ['supernaedo2.3.1']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.parent.parent.item.name == root_name
+    assert len(exp_node.children) == 0
+    # 2
+    # |
+    # 2.3
+    # |
+    # 2.3.1
+    assert len(list(exp_node.root)) == 3
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    for node in exp_node.root:
+        node.item._experiment.refers['adapter'] = Adapter.build([])
+
+    query = {'status': 'completed'}
+    assert len(exp_node.parent.parent.item.fetch_trials(query)) == 6
+    assert len(exp_node.parent.item.fetch_trials(query)) == 4
+    assert len(exp_node.item.fetch_trials(query)) == 2
+
+    assert len(experiment.fetch_trials_tree(query)) == 6 + 4 + 2
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_children_children_fetch_trials(create_db_instance):
+    """Test that experiment fetch trials from grand children properly (adapters are muted)"""
+    experiment_name = 'supernaedo2'
+    root_name = 'supernaedo2'
+    leaf_names = ['supernaedo2.3.1']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.children[0].children[0].item.name == leaf_names[0]
+    # 2
+    # |
+    # 2.3
+    # |
+    # 2.3.1
+    assert len(list(exp_node.root)) == 3
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    for node in exp_node.root:
+        node.item._experiment.refers['adapter'] = Adapter.build([])
+
+    query = {'status': 'completed'}
+    assert len(exp_node.item.fetch_trials(query)) == 6
+    assert len(exp_node.children[0].item.fetch_trials(query)) == 4
+    assert len(exp_node.children[0].children[0].item.fetch_trials(query)) == 2
+
+    assert len(experiment.fetch_trials_tree(query)) == 6 + 4 + 2
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_deletion_adapter_forward(create_db_instance):
+    """Test that all decoding_layer=gru pass to children"""
+    experiment_name = 'supernaedo2.1'
+    root_name = 'supernaedo2'
+    leaf_names = ['supernaedo2.1']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.parent.item.name == root_name
+    assert len(exp_node.children) == 0
+    # 2
+    # |
+    # 2.1
+    assert len(list(exp_node.root)) == 2
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    query = {'status': 'completed'}
+    assert len(exp_node.item.fetch_trials(query)) == 1
+    assert len(exp_node.parent.item.fetch_trials(query)) == 6
+
+    adapter = experiment.refers['adapter']
+    assert len(adapter.forward(exp_node.parent.item.fetch_trials(query))) == 1
+    assert len(experiment.fetch_trials_tree(query)) == 1 + 1
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_deletion_adapter_backward(create_db_instance):
+    """Test that all decoding_layer are passed with gru to parent"""
+    experiment_name = 'supernaedo2'
+    root_name = 'supernaedo2'
+    leaf_names = ['supernaedo2.1']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.children[0].item.name == leaf_names[0]
+    # 2
+    # |
+    # 2.1
+    assert len(list(exp_node.root)) == 2
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    query = {'status': 'completed'}
+    assert len(exp_node.item.fetch_trials(query)) == 6
+    assert len(exp_node.children[0].item.fetch_trials(query)) == 1
+
+    adapter = exp_node.children[0].item.refers['adapter']
+    assert len(adapter.backward(exp_node.children[0].item.fetch_trials(query))) == 1
+    assert len(experiment.fetch_trials_tree(query)) == 6 + 1
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_renaming_forward(create_db_instance):
+    """Test that all encoding_layer are renamed to encoding in children"""
+    experiment_name = 'supernaedo2.3'
+    root_name = 'supernaedo2'
+    leaf_names = ['supernaedo2.3']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.parent.item.name == root_name
+    # 2
+    # |
+    # 2.1
+    assert len(list(exp_node.root)) == 2
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    query = {'status': 'completed'}
+    parent_trials = exp_node.parent.item.fetch_trials(query)
+    assert len(parent_trials) == 6
+    assert len(exp_node.item.fetch_trials(query)) == 4
+
+    assert all((trial.params[0].name == "/encoding_layer") for trial in parent_trials)
+
+    adapter = experiment.refers['adapter']
+    adapted_parent_trials = adapter.forward(parent_trials)
+    assert len(adapted_parent_trials) == 6
+    assert all((trial.params[0].name == "/encoding") for trial in adapted_parent_trials)
+
+    assert len(experiment.fetch_trials_tree(query)) == 6 + 4
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_renaming_backward(create_db_instance):
+    """Test that all encoding are renamed to encoding_layer in parent"""
+    experiment_name = 'supernaedo2'
+    root_name = 'supernaedo2'
+    leaf_names = ['supernaedo2.3']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.children[0].item.name == leaf_names[0]
+    # 2
+    # |
+    # 2.1
+    assert len(list(exp_node.root)) == 2
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    query = {'status': 'completed'}
+    children_trials = exp_node.children[0].item.fetch_trials(query)
+    assert len(children_trials) == 4
+    assert len(exp_node.item.fetch_trials(query)) == 6
+
+    assert all((trial.params[0].name == "/encoding") for trial in children_trials)
+
+    adapter = exp_node.children[0].item.refers['adapter']
+    adapted_children_trials = adapter.backward(children_trials)
+    assert len(adapted_children_trials) == 4
+    assert all((trial.params[0].name == "/encoding_layer") for trial in adapted_children_trials)
+
+    assert len(experiment.fetch_trials_tree(query)) == 6 + 4
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_prior_change_forward(create_db_instance):
+    """Test that trials from parent only pass to children if valid in the new prior"""
+    experiment_name = 'supernaedo2.3.1'
+    root_name = 'supernaedo2.3'
+    leaf_names = ['supernaedo2.3.1']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.parent.item.name == root_name
+    # 2.3
+    # |
+    # 2.3.1
+    assert len(list(exp_node.root)) == 2
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    query = {'status': 'completed'}
+    parent_trials = exp_node.parent.item.fetch_trials(query)
+    assert len(parent_trials) == 4
+    assert len(exp_node.item.fetch_trials(query)) == 2
+
+    adapter = experiment.refers['adapter']
+    adapted_parent_trials = adapter.forward(parent_trials)
+    assert len(adapted_parent_trials) == 1
+    assert len(experiment.fetch_trials_tree(query)) == 2 + 1
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_prior_change_backward(create_db_instance):
+    """Test that all encoding are renamed to encoding_layer in parent"""
+    experiment_name = 'supernaedo2.3'
+    root_name = 'supernaedo2.3'
+    leaf_names = ['supernaedo2.3.1']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.children[0].item.name == leaf_names[0]
+    # 2.3
+    # |
+    # 2.3.1
+    assert len(list(exp_node.root)) == 2
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    query = {'status': 'completed'}
+    children_trials = exp_node.children[0].item.fetch_trials(query)
+    assert len(children_trials) == 2
+    assert len(exp_node.item.fetch_trials(query)) == 4
+
+    adapter = exp_node.children[0].item.refers['adapter']
+    adapted_children_trials = adapter.backward(children_trials)
+    assert len(adapted_children_trials) == 1
+
+    assert len(experiment.fetch_trials_tree(query)) == 4 + 1
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_code_change_noeffect_forward(create_db_instance):
+    """Test that all trials pass to children when code change type is 'noeffect'"""
+    experiment_name = 'supernaedo2.3.1.1'
+    root_name = 'supernaedo2.3.1'
+    leaf_names = ['supernaedo2.3.1.1']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.parent.item.name == root_name
+    # 2.3.1
+    # |
+    # 2.3.1.1
+    assert len(list(exp_node.root)) == 2
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    query = {'status': 'completed'}
+    parent_trials = exp_node.parent.item.fetch_trials(query)
+    assert len(parent_trials) == 2
+    assert len(exp_node.item.fetch_trials(query)) == 1
+
+    adapter = experiment.refers['adapter']
+    assert adapter.adapters[0].change_type == CodeChange.NOEFFECT
+    adapted_parent_trials = adapter.forward(parent_trials)
+    assert len(adapted_parent_trials) == 2
+    assert len(experiment.fetch_trials_tree(query)) == 2 + 1
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_code_change_noeffect_backward(create_db_instance):
+    """Test that all trials pass to parent when code change type is 'noeffect'"""
+    experiment_name = 'supernaedo2.3.1'
+    root_name = 'supernaedo2.3.1'
+    leaf_names = ['supernaedo2.3.1.1']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.children[0].item.name == leaf_names[0]
+    # 2.3
+    # |
+    # 2.3.1
+    assert len(list(exp_node.root)) == 2
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    query = {'status': 'completed'}
+    children_trials = exp_node.children[0].item.fetch_trials(query)
+    assert len(children_trials) == 1
+    assert len(exp_node.item.fetch_trials(query)) == 2
+
+    adapter = exp_node.children[0].item.refers['adapter']
+    assert adapter.adapters[0].change_type == CodeChange.NOEFFECT
+    adapted_children_trials = adapter.backward(children_trials)
+    assert len(adapted_children_trials) == 1
+
+    assert len(experiment.fetch_trials_tree(query)) == 2 + 1
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_code_change_unsure_forward(create_db_instance):
+    """Test that all trials pass to children when code change type is 'unsure'"""
+    experiment_name = 'supernaedo2.3.1.2'
+    root_name = 'supernaedo2.3.1'
+    leaf_names = ['supernaedo2.3.1.2']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.parent.item.name == root_name
+    # 2.3.1
+    # |
+    # 2.3.1.1
+    assert len(list(exp_node.root)) == 2
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    query = {'status': 'completed'}
+    parent_trials = exp_node.parent.item.fetch_trials(query)
+    assert len(parent_trials) == 2
+    assert len(exp_node.item.fetch_trials(query)) == 1
+
+    adapter = experiment.refers['adapter']
+    assert adapter.adapters[0].change_type == CodeChange.UNSURE
+    adapted_parent_trials = adapter.forward(parent_trials)
+    assert len(adapted_parent_trials) == 2
+    assert len(experiment.fetch_trials_tree(query)) == 2 + 1
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_code_change_unsure_backward(create_db_instance):
+    """Test that no trials pass to parent when code change type is 'unsure'"""
+    experiment_name = 'supernaedo2.3.1'
+    root_name = 'supernaedo2.3.1'
+    leaf_names = ['supernaedo2.3.1.2']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.children[0].item.name == leaf_names[0]
+    # 2.3
+    # |
+    # 2.3.1
+    assert len(list(exp_node.root)) == 2
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    query = {'status': 'completed'}
+    children_trials = exp_node.children[0].item.fetch_trials(query)
+    assert len(children_trials) == 1
+    assert len(exp_node.item.fetch_trials(query)) == 2
+
+    adapter = exp_node.children[0].item.refers['adapter']
+    assert adapter.adapters[0].change_type == CodeChange.UNSURE
+    adapted_children_trials = adapter.backward(children_trials)
+    assert len(adapted_children_trials) == 0
+
+    assert len(experiment.fetch_trials_tree(query)) == 2 + 0
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_code_change_break_forward(create_db_instance):
+    """Test that no trials pass to children when code change type is 'break'"""
+    experiment_name = 'supernaedo2.3.1.3'
+    root_name = 'supernaedo2.3.1'
+    leaf_names = ['supernaedo2.3.1.3']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.parent.item.name == root_name
+    # 2.3.1
+    # |
+    # 2.3.1.1
+    assert len(list(exp_node.root)) == 2
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    query = {'status': 'completed'}
+    parent_trials = exp_node.parent.item.fetch_trials(query)
+    assert len(parent_trials) == 2
+    assert len(exp_node.item.fetch_trials(query)) == 1
+
+    adapter = experiment.refers['adapter']
+    assert adapter.adapters[0].change_type == CodeChange.BREAK
+    adapted_parent_trials = adapter.forward(parent_trials)
+    assert len(adapted_parent_trials) == 0
+    assert len(experiment.fetch_trials_tree(query)) == 1 + 0
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_code_change_break_backward(create_db_instance):
+    """Test that no trials pass to parent when code change type is 'break'"""
+    experiment_name = 'supernaedo2.3.1'
+    root_name = 'supernaedo2.3.1'
+    leaf_names = ['supernaedo2.3.1.3']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.children[0].item.name == leaf_names[0]
+    # 2.3
+    # |
+    # 2.3.1
+    assert len(list(exp_node.root)) == 2
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    query = {'status': 'completed'}
+    children_trials = exp_node.children[0].item.fetch_trials(query)
+    assert len(children_trials) == 1
+    assert len(exp_node.item.fetch_trials(query)) == 2
+
+    adapter = exp_node.children[0].item.refers['adapter']
+    assert adapter.adapters[0].change_type == CodeChange.BREAK
+    adapted_children_trials = adapter.backward(children_trials)
+    assert len(adapted_children_trials) == 0
+
+    assert len(experiment.fetch_trials_tree(query)) == 2 + 0
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_algo_change_forward(create_db_instance):
+    """Test that all trials pass to children when algorithm is changed"""
+    experiment_name = 'supernaedo2.2.1'
+    root_name = 'supernaedo2.2'
+    leaf_names = ['supernaedo2.2.1']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.parent.item.name == root_name
+    # 2.2
+    # |
+    # 2.2.1
+    assert len(list(exp_node.root)) == 2
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    query = {'status': 'completed'}
+    parent_trials = exp_node.parent.item.fetch_trials(query)
+    assert len(parent_trials) == 1
+    assert len(exp_node.item.fetch_trials(query)) == 1
+
+    adapter = experiment.refers['adapter']
+    adapted_parent_trials = adapter.forward(parent_trials)
+    assert len(adapted_parent_trials) == 1
+    assert len(experiment.fetch_trials_tree(query)) == 1 + 1
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_algo_change_backward(create_db_instance):
+    """Test that all trials pass to parent when algorithm is changed"""
+    experiment_name = 'supernaedo2.2'
+    root_name = 'supernaedo2.2'
+    leaf_names = ['supernaedo2.2.1']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.children[0].item.name == leaf_names[0]
+    # 2.2
+    # |
+    # 2.2.1
+    assert len(list(exp_node.root)) == 2
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    query = {'status': 'completed'}
+    children_trials = exp_node.children[0].item.fetch_trials(query)
+    assert len(children_trials) == 1
+    assert len(exp_node.item.fetch_trials(query)) == 1
+
+    adapter = exp_node.children[0].item.refers['adapter']
+    adapted_children_trials = adapter.backward(children_trials)
+    assert len(adapted_children_trials) == 1
+
+    assert len(experiment.fetch_trials_tree(query)) == 1 + 1
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_full_backward(create_db_instance):
+    """Test that trials are adapted properly up to root"""
+    experiment_name = 'supernaedo2'
+    root_name = None
+    leaf_names = []
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.children[0].item.name == 'supernaedo2.1'
+    assert exp_node.children[1].item.name == 'supernaedo2.2'
+    assert exp_node.children[2].item.name == 'supernaedo2.3'
+    assert exp_node.children[1].children[0].item.name == 'supernaedo2.2.1'
+    assert exp_node.children[2].children[0].item.name == 'supernaedo2.3.1'
+    assert exp_node.children[2].children[0].children[0].item.name == 'supernaedo2.3.1.1'
+    assert exp_node.children[2].children[0].children[1].item.name == 'supernaedo2.3.1.2'
+    assert exp_node.children[2].children[0].children[2].item.name == 'supernaedo2.3.1.3'
+    # 2
+    # |    \      \
+    # 2.1  2.2    2.3
+    #      |      |
+    #      2.2.1  2.3.1
+    #             |        \         \
+    #             2.3.1.1  2.3.1.2  2.3.1.3
+    assert len(list(exp_node)) == 9
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    query = {'status': 'completed'}
+    assert len(exp_node.item.fetch_trials(query)) == 6
+    assert len(exp_node.children[0].item.fetch_trials(query)) == 1
+    assert len(exp_node.children[1].item.fetch_trials(query)) == 1
+    assert len(exp_node.children[2].item.fetch_trials(query)) == 4
+    assert len(exp_node.children[1].children[0].item.fetch_trials(query)) == 1
+    assert len(exp_node.children[2].children[0].item.fetch_trials(query)) == 2
+    assert len(exp_node.children[2].children[0].children[0].item.fetch_trials(query)) == 1
+    assert len(exp_node.children[2].children[0].children[1].item.fetch_trials(query)) == 1
+    assert len(exp_node.children[2].children[0].children[2].item.fetch_trials(query)) == 1
+
+    assert len(experiment.fetch_trials_tree(query)) == 15
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_full_forward(create_db_instance):
+    """Test that trials are adapted properly down to leaf"""
+    experiment_name = 'supernaedo2.3.1.1'
+    root_name = None
+    leaf_names = []
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.parent.item.name == 'supernaedo2.3.1'
+    assert exp_node.parent.parent.item.name == 'supernaedo2.3'
+    assert exp_node.parent.parent.parent.item.name == 'supernaedo2'
+    # 2
+    # |
+    # 2.3
+    # |
+    # 2.3.1
+    # |
+    # 2.3.1.1
+    assert len(list(exp_node.root)) == 4
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    query = {'status': 'completed'}
+    assert len(exp_node.item.fetch_trials(query)) == 1
+    assert len(exp_node.parent.item.fetch_trials(query)) == 2
+    assert len(exp_node.parent.parent.item.fetch_trials(query)) == 4
+    assert len(exp_node.parent.parent.parent.item.fetch_trials(query)) == 6
+
+    assert len(experiment.fetch_trials_tree(query)) == 2 + 1 + 2 + 1
+
+
+@pytest.mark.usefixtures("trial_id_substitution")
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_full_forward_full_backward(create_db_instance):
+    """Test that trials are adapted properly forward from parent and backward from leafs"""
+    experiment_name = 'supernaedo2.3'
+    root_name = 'supernaedo2'
+    leaf_names = []
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.parent.name == root_name
+    assert exp_node.children[0].item.name == 'supernaedo2.3.1'
+    assert exp_node.children[0].children[0].item.name == 'supernaedo2.3.1.1'
+    assert exp_node.children[0].children[1].item.name == 'supernaedo2.3.1.2'
+    assert exp_node.children[0].children[2].item.name == 'supernaedo2.3.1.3'
+    # 2
+    # |
+    # 2.3
+    # |
+    # 2.3.1
+    # |        \        \
+    # 2.3.1.1  2.3.1.2  2.3.1.3
+    assert len(list(exp_node.root)) == 6
+
+    experiment.connect_to_version_control_tree(exp_node)
+
+    query = {'status': 'completed'}
+    assert len(exp_node.parent.item.fetch_trials(query)) == 6
+    assert len(exp_node.item.fetch_trials(query)) == 4
+    assert len(exp_node.children[0].item.fetch_trials(query)) == 2
+    assert len(exp_node.children[0].children[0].item.fetch_trials(query)) == 1
+    assert len(exp_node.children[0].children[1].item.fetch_trials(query)) == 1
+    assert len(exp_node.children[0].children[2].item.fetch_trials(query)) == 1
+
+    assert len(experiment.fetch_trials_tree(query)) == 6 + 4 + 1 + 1 + 0 + 0

--- a/tests/unittests/core/evc/test_tree.py
+++ b/tests/unittests/core/evc/test_tree.py
@@ -1,0 +1,423 @@
+"""Test for generic :class:`orion.core.evc.tree`"""
+
+from orion.core.evc.tree import DepthFirstTraversal, flattened, PreOrderTraversal, TreeNode
+
+
+def test_node_creation():
+    """Test empty initialization of tree node"""
+    TreeNode("test")
+    TreeNode("test", None, tuple())
+
+
+def test_node_creation_with_parent():
+    """Test assignement of parent on initialization"""
+    parent = TreeNode("test")
+    child = TreeNode("test", parent)
+
+    assert child.parent is parent
+
+    assert parent.children[0] is child
+
+
+def test_node_set_parent():
+    """Test assignement of parent"""
+    parent = TreeNode("test")
+    child = TreeNode("test")
+
+    child.set_parent(parent)
+
+    assert child.parent is parent
+
+    assert parent.children[0] is child
+
+
+def test_node_set_no_parent():
+    """Test assignement of no parent, meaning droping the parent"""
+    parent = TreeNode("test")
+    child = TreeNode("test")
+
+    child.set_parent(parent)
+
+    assert child.parent is parent
+    assert parent.children[0] is child
+
+    child.set_parent(None)
+
+    assert child.parent is None
+    assert len(parent.children) == 0
+
+
+def test_node_drop_parent():
+    """Test dropping parent"""
+    parent = TreeNode("test")
+    child = TreeNode("test")
+
+    child.set_parent(parent)
+
+    assert child.parent is parent
+    assert parent.children[0] is child
+
+    child.drop_parent()
+
+    assert child.parent is None
+    assert len(parent.children) == 0
+
+
+def test_node_add_child():
+    """Test assignement of child"""
+    parent = TreeNode("test")
+    child = TreeNode("test")
+
+    parent.add_children(child)
+
+    assert parent.children[0] is child
+    assert child.parent is parent
+
+
+def test_node_remove_child():
+    """Test removing child"""
+    parent = TreeNode("test")
+    child = TreeNode("test")
+
+    parent.add_children(child)
+
+    assert child.parent is parent
+    assert parent.children[0] is child
+
+    parent.drop_children(child)
+
+    assert len(parent.children) == 0
+    assert child.parent is None
+
+
+def test_node_add_children():
+    """Test assignement of children"""
+    parent = TreeNode("test")
+    child1 = TreeNode("test1")
+    child2 = TreeNode("test2")
+
+    parent.add_children(child1, child2)
+
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+    assert child1.parent is parent
+    assert child2.parent is parent
+
+
+def test_node_remove_children_sequentially():
+    """Test removing children one after the other"""
+    parent = TreeNode("test")
+    child1 = TreeNode("test1")
+    child2 = TreeNode("test2")
+
+    parent.add_children(child1, child2)
+
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+    assert child1.parent is parent
+    assert child2.parent is parent
+
+    parent.drop_children(child1)
+
+    assert len(parent.children) == 1
+    assert child1.parent is None
+    assert parent.children[0] is child2
+    assert child2.parent is parent
+
+    parent.drop_children(child2)
+
+    assert len(parent.children) == 0
+    assert child1.parent is None
+    assert child2.parent is None
+
+
+def test_node_remove_children_in_batch():
+    """Test removing children all at the same time"""
+    parent = TreeNode("test")
+    child1 = TreeNode("test1")
+    child2 = TreeNode("test2")
+
+    parent.add_children(child1, child2)
+
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+    assert child1.parent is parent
+    assert child2.parent is parent
+
+    parent.drop_children(child1, child2)
+
+    assert len(parent.children) == 0
+    assert child1.parent is None
+    assert child2.parent is None
+
+
+def test_parent_parent():
+    """Test path through two level of parents"""
+    grand_parent = TreeNode("test")
+    parent = TreeNode("test", grand_parent)
+    child = TreeNode("test", parent)
+
+    assert child.parent is parent
+    assert child.parent.parent is grand_parent
+    assert grand_parent.children[0] is parent
+    assert grand_parent.children[0].children[0] is child
+
+
+def test_children_children():
+    """Test path through two level of children"""
+    child = TreeNode("test")
+    parent = TreeNode("test", children=[child])
+    grand_parent = TreeNode("test", children=[parent])
+
+    assert child.parent is parent
+    assert child.parent.parent is grand_parent
+    assert grand_parent.children[0] is parent
+    assert grand_parent.children[0].children[0] is child
+
+
+def test_root():
+    """Test root access from leaf"""
+    child = TreeNode("test")
+    parent = TreeNode("test", children=[child])
+    grand_parent = TreeNode("test", children=[parent])
+
+    assert child.root is grand_parent
+    assert child.root is parent.root
+    assert grand_parent.root is grand_parent
+
+
+def test_node_parent_reinsertion():
+    """Test that replacing a parent with the same one does not change anything"""
+    parent = TreeNode("test")
+    child1 = TreeNode("test", parent)
+    child2 = TreeNode("test", parent)
+
+    assert child1.parent is parent
+    assert child2.parent is parent
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+
+    child1.set_parent(parent)
+
+    assert child1.parent is parent
+    assert child2.parent is parent
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+
+    child2.set_parent(parent)
+
+    assert child1.parent is parent
+    assert child2.parent is parent
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+
+
+def test_node_children_reinsertion():
+    """Test that replacing a children with the same one does not change anything"""
+    parent = TreeNode("test")
+    child1 = TreeNode("test", parent)
+    child2 = TreeNode("test", parent)
+
+    assert child1.parent is parent
+    assert child2.parent is parent
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+
+    parent.add_children(child1)
+
+    assert child1.parent is parent
+    assert child2.parent is parent
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+
+    parent.add_children(child2)
+
+    assert child1.parent is parent
+    assert child2.parent is parent
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+
+
+def test_node_set_parent_drop_children():
+    """Test that replacing a parent removes the node from parent's children"""
+    grand_parent = TreeNode("test")
+    parent = TreeNode("test", grand_parent)
+    child = TreeNode("test", parent)
+
+    assert child.parent is parent
+    assert child.parent.parent is grand_parent
+    assert grand_parent.children[0] is parent
+    assert grand_parent.children[0].children[0] is child
+
+    # That's silly...
+    child.set_parent(grand_parent)
+
+    assert child.parent is grand_parent
+    assert len(grand_parent.children) == 2
+    assert grand_parent.parent is None
+    assert len(parent.children) == 0
+    assert parent.parent is grand_parent
+
+
+def test_node_add_children_drop_children():
+    """Test that replacing a children removes the node from previous parent's children"""
+    grand_parent = TreeNode("test")
+    parent = TreeNode("test", grand_parent)
+    child = TreeNode("test", parent)
+
+    assert child.parent is parent
+    assert child.parent.parent is grand_parent
+    assert grand_parent.children[0] is parent
+    assert grand_parent.children[0].children[0] is child
+
+    # That's silly...
+    grand_parent.add_children(child)
+
+    assert child.parent is grand_parent
+    assert len(grand_parent.children) == 2
+    assert grand_parent.parent is None
+    assert len(parent.children) == 0
+    assert parent.parent is grand_parent
+
+
+def test_preorder_traversal():
+    """Test order retrieval of DepthFirstTraversal"""
+    # a
+    # |   \  \   \
+    # b    c  d   e
+    # | \         |
+    # f  g        h
+    root = TreeNode("a")
+    b = TreeNode("b", root)
+    TreeNode("c", root)
+    TreeNode("d", root)
+    e = TreeNode("e", root)
+
+    TreeNode("f", b)
+    TreeNode("g", b)
+
+    TreeNode("h", e)
+
+    rval = [node.item for node in PreOrderTraversal(root)]
+    assert rval == ['a', 'b', 'f', 'g', 'c', 'd', 'e', 'h']
+
+
+def test_depth_first_traversal():
+    """Test order retrieval of DepthFirstTraversal"""
+    # a
+    # |   \  \   \
+    # b    c  d   e
+    # | \         |
+    # f  g        h
+    root = TreeNode("a")
+    b = TreeNode("b", root)
+    TreeNode("c", root)
+    TreeNode("d", root)
+    e = TreeNode("e", root)
+
+    TreeNode("f", b)
+    TreeNode("g", b)
+
+    TreeNode("h", e)
+
+    rval = [node.item for node in DepthFirstTraversal(root)]
+    assert rval == ['f', 'g', 'b', 'c', 'd', 'h', 'e', 'a']
+
+
+def test_map_children():
+    """Test recursive application of map on children"""
+    # a
+    # |   \  \   \
+    # b    c  d   e
+    # | \         |
+    # f  g        h
+    #
+    # Should become
+    #
+    # 2
+    # |   \  \   \
+    # 3    3  3   3
+    # | \         |
+    # 4  4        4
+
+    root = TreeNode(1)
+    b = TreeNode(1, root)
+    TreeNode(1, root)
+    TreeNode(1, root)
+    e = TreeNode(1, root)
+
+    TreeNode(1, b)
+    TreeNode(1, b)
+
+    TreeNode(1, e)
+
+    def increment(node, children):
+        for child in TreeNode(0, None, children):
+            child.item += 1
+
+        return node.item + 1
+
+    rval = root.map(increment, root.children)
+    assert [node.item for node in rval] == [2, 3, 4, 4, 3, 3, 3, 4]
+
+
+def test_map_parent():
+    """Test recursive application of map on parents"""
+    # a
+    # |   \  \   \
+    # b    c  d   e
+    # | \         |
+    # f  g        h
+    #
+    # Will give
+    #
+    # 4
+    # |
+    # 3
+    # |
+    # 2
+
+    root = TreeNode(1)
+    b = TreeNode(1, root)
+    TreeNode(1, root)
+    TreeNode(1, root)
+    e = TreeNode(1, root)
+
+    f = TreeNode(1, b)
+    TreeNode(1, b)
+
+    h = TreeNode(1, e)
+
+    def increment_parent(node, parent):
+        if parent is not None:
+            for parent in parent.root:
+                parent.item += 1
+
+        return node.item + 1
+
+    rval = f.map(increment_parent, f.parent)
+    assert [node.item for node in rval.root] == [4, 3, 2]
+
+    rval = h.map(increment_parent, h.parent)
+    assert [node.item for node in rval.root] == [4, 3, 2]
+
+
+def test_flattened():
+    """Test flattened tree into a list, retrieving items"""
+    # a
+    # |   \  \   \
+    # b    c  d   e
+    # | \         |
+    # f  g        h
+    root = TreeNode("a")
+    b = TreeNode("b", root)
+    TreeNode("c", root)
+    TreeNode("d", root)
+    e = TreeNode("e", root)
+
+    TreeNode("f", b)
+    TreeNode("g", b)
+
+    TreeNode("h", e)
+
+    assert flattened(root) == ['a', 'b', 'f', 'g', 'c', 'd', 'e', 'h']

--- a/tests/unittests/core/evc/test_tree.py
+++ b/tests/unittests/core/evc/test_tree.py
@@ -375,7 +375,7 @@ def test_map_children():
         for child in TreeNode(0, None, children):
             child.item += 1
 
-        return node.item + 1
+        return node.item + 1, children
 
     rval = root.map(increment, root.children)
     assert [node.item for node in rval] == [2, 3, 4, 4, 3, 3, 3, 4]
@@ -413,7 +413,7 @@ def test_map_parent():
             for parent in parent.root:
                 parent.item += 1
 
-        return node.item + 1
+        return node.item + 1, parent
 
     rval = f.map(increment_parent, f.parent)
     assert [node.item for node in rval.root] == [4, 3, 2]

--- a/tests/unittests/core/evc/test_tree.py
+++ b/tests/unittests/core/evc/test_tree.py
@@ -151,6 +151,26 @@ def test_node_remove_children_in_batch():
     assert child2.parent is None
 
 
+def test_node_remove_all_children():
+    """Test drop_children() drops all of them"""
+    parent = TreeNode("test")
+    child1 = TreeNode("test1")
+    child2 = TreeNode("test2")
+
+    parent.add_children(child1, child2)
+
+    assert parent.children[0] is child1
+    assert parent.children[1] is child2
+    assert child1.parent is parent
+    assert child2.parent is parent
+
+    parent.drop_children()
+
+    assert len(parent.children) == 0
+    assert child1.parent is None
+    assert child2.parent is None
+
+
 def test_parent_parent():
     """Test path through two level of parents"""
     grand_parent = TreeNode("test")

--- a/tests/unittests/core/experiment.yaml
+++ b/tests/unittests/core/experiment.yaml
@@ -26,13 +26,9 @@
   # reuse their trial history
   # set defaults for their missing arguments
   refers:
-    name: supernaedo1
-    user: tsirif
-
-    params:
-      - name: decoding_layer
-        type: categorical
-        value: gru
+    root_id: supernaedo2
+    parent_id: null
+    adapter: []
 
   # orion's configuration
   pool_size: 2
@@ -60,12 +56,9 @@
     user_version: ~
     user_commit_hash: as5f7asf5asfa7sf
   refers:
-    name: supernaedo1
-    user: tsirif
-    params:
-      - name: decoding_layer
-        type: categorical
-        value: gru
+    root_id: supernaedo3
+    parent_id: null
+    adapter: []
   pool_size: 2
   max_trials: 1000
   algorithms:
@@ -88,12 +81,9 @@
     user_version: ~
     user_commit_hash: as5f7asf5asfa7sf
   refers:
-    name: supernaedo1
-    user: tsirif
-    params:
-      - name: decoding_layer
-        type: categorical
-        value: gru
+    root_id: supernaedo4
+    parent_id: null
+    adapter: []
   pool_size: 2
   max_trials: 1
   algorithms:
@@ -116,12 +106,9 @@
     user_version: ~
     user_commit_hash: as5f7asf5asfa7sf
   refers:
-    name: supernaedo1
-    user: tsirif
-    params:
-      - name: decoding_layer
-        type: categorical
-        value: gru
+    root_id: supernaedo2
+    parent_id: null
+    adapter: []
   pool_size: 2
   max_trials: 1000
   algorithms:
@@ -131,6 +118,308 @@
       judgement: ~
       suspend: False
       done: False
+
+
+- name: supernaedo2.1
+
+  metadata:
+    # inferred from os
+    user: tsirif
+    datetime: 2017-11-22T20:00:00
+    # from orion.__version__
+    orion_version: 0.1
+    # from `orion`'s args
+    user_script: full_path/main.py
+    # from `orion`'s args
+    user_args: ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])"]
+    # from user's vsc, e.g. git
+    user_vcs: git
+    user_version: ~
+    user_commit_hash: as5f7asf5asfa7sf
+
+  refers:
+    root_id: supernaedo2
+    parent_id: supernaedo2
+    adapter:
+      - of_type: dimensiondeletion
+        param:
+          name: /decoding_layer
+          type: categorical
+          value: gru
+
+  # orion's configuration
+  pool_size: 2
+  max_trials: 1000
+
+  # functional info
+  status: pending  # pending, done, broken
+
+  # **complete** specification of algorithms used
+  # user's configuration, but defaults are inferred
+  algorithms:
+    random: {}
+  
+- name: supernaedo2.2
+
+  metadata:
+    # inferred from os
+    user: tsirif
+    datetime: 2017-11-22T20:00:00
+    # from orion.__version__
+    orion_version: 0.1
+    # from `orion`'s args
+    user_script: full_path/main.py
+    # from `orion`'s args
+    user_args: ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])"]
+    # from user's vsc, e.g. git
+    user_vcs: git
+    user_version: ~
+    user_commit_hash: as5f7asf5asfa7sf
+
+  refers:
+    root_id: supernaedo2
+    parent_id: supernaedo2
+    adapter:
+      - of_type: dimensiondeletion
+        param:
+          name: /decoding_layer
+          type: categorical
+          value: lstm_with_attention
+
+  # orion's configuration
+  pool_size: 2
+  max_trials: 1000
+
+  # functional info
+  status: pending  # pending, done, broken
+
+  # **complete** specification of algorithms used
+  # user's configuration, but defaults are inferred
+  algorithms:
+    random: {}
+
+- name: supernaedo2.3
+
+  metadata:
+    # inferred from os
+    user: tsirif
+    datetime: 2017-11-22T20:00:00
+    # from orion.__version__
+    orion_version: 0.1
+    # from `orion`'s args
+    user_script: full_path/main.py
+    # from `orion`'s args
+    user_args: ["--encoding~choices(['rnn', 'lstm', 'gru'])", "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"]
+    # from user's vsc, e.g. git
+    user_vcs: git
+    user_version: ~
+    user_commit_hash: as5f7asf5asfa7sf
+
+  refers:
+    root_id: supernaedo2
+    parent_id: supernaedo2
+    adapter:
+      - of_type: dimensionrenaming 
+        old_name: /encoding_layer
+        new_name: /encoding
+
+  # orion's configuration
+  pool_size: 2
+  max_trials: 1000
+
+  # functional info
+  status: pending  # pending, done, broken
+
+  # **complete** specification of algorithms used
+  # user's configuration, but defaults are inferred
+  algorithms: 
+    random: {}
+
+- name: supernaedo2.3.1
+
+  metadata:
+    # inferred from os
+    user: tsirif
+    datetime: 2017-11-22T20:00:00
+    # from orion.__version__
+    orion_version: 0.1
+    # from `orion`'s args
+    user_script: full_path/main.py
+    # from `orion`'s args
+    user_args: ["--encoding~choices(['rnn', 'lstm_with_attention', 'gru'])"]
+    # from user's vsc, e.g. git
+    user_vcs: git
+    user_version: ~
+    user_commit_hash: as5f7asf5asfa7sf
+
+  refers:
+    root_id: supernaedo2
+    parent_id: supernaedo2.3
+    adapter:
+      - of_type: dimensiondeletion
+        param:
+          name: /decoding_layer
+          type: categorical
+          value: lstm_with_attention
+      - of_type: dimensionpriorchange
+        name: /encoding
+        old_prior: "choices(['rnn', 'lstm', 'gru'])"
+        new_prior: "choices(['rnn', 'lstm_with_attention', 'gru'])"
+
+  # orion's configuration
+  pool_size: 2
+  max_trials: 1000
+
+  # functional info
+  status: pending  # pending, done, broken
+
+  # **complete** specification of algorithms used
+  # user's configuration, but defaults are inferred
+  algorithms: 
+    random: {}
+
+- name: supernaedo2.3.1.1
+
+  metadata:
+    # inferred from os
+    user: tsirif
+    datetime: 2017-11-22T20:00:00
+    # from orion.__version__
+    orion_version: 0.1
+    # from `orion`'s args
+    user_script: full_path/main.py
+    # from `orion`'s args
+    user_args: ["--encoding~choices(['rnn', 'lstm_with_attention', 'gru'])"]
+    # from user's vsc, e.g. git
+    user_vcs: git
+    user_version: ~
+    user_commit_hash: qwwoi2iu12e
+
+  refers:
+    root_id: supernaedo2
+    parent_id: supernaedo2.3.1
+    adapter:
+      - of_type: codechange
+        change_type: noeffect
+
+  # orion's configuration
+  pool_size: 2
+  max_trials: 1000
+
+  # functional info
+  status: pending  # pending, done, broken
+
+  # **complete** specification of algorithms used
+  # user's configuration, but defaults are inferred
+  algorithms: 
+    random: {}
+
+- name: supernaedo2.3.1.2
+
+  metadata:
+    # inferred from os
+    user: tsirif
+    datetime: 2017-11-22T20:00:00
+    # from orion.__version__
+    orion_version: 0.1
+    # from `orion`'s args
+    user_script: full_path/main.py
+    # from `orion`'s args
+    user_args: ["--encoding~choices(['rnn', 'lstm_with_attention', 'gru'])"]
+    # from user's vsc, e.g. git
+    user_vcs: git
+    user_version: ~
+    user_commit_hash: kqbwepuzxc
+
+  refers:
+    root_id: supernaedo2
+    parent_id: supernaedo2.3.1
+    adapter:
+      - of_type: codechange
+        change_type: unsure
+
+  # orion's configuration
+  pool_size: 2
+  max_trials: 1000
+
+  # functional info
+  status: pending  # pending, done, broken
+
+  # **complete** specification of algorithms used
+  # user's configuration, but defaults are inferred
+  algorithms: 
+    random: {}
+
+- name: supernaedo2.3.1.3
+
+  metadata:
+    # inferred from os
+    user: tsirif
+    datetime: 2017-11-22T20:00:00
+    # from orion.__version__
+    orion_version: 0.1
+    # from `orion`'s args
+    user_script: full_path/main.py
+    # from `orion`'s args
+    user_args: ["--encoding~choices(['rnn', 'lstm_with_attention', 'gru'])"]
+    # from user's vsc, e.g. git
+    user_vcs: git
+    user_version: ~
+    user_commit_hash: ioqwepiuqwe
+
+  refers:
+    root_id: supernaedo2
+    parent_id: supernaedo2.3.1
+    adapter:
+      - of_type: codechange
+        change_type: break
+
+  # orion's configuration
+  pool_size: 2
+  max_trials: 1000
+
+  # functional info
+  status: pending  # pending, done, broken
+
+  # **complete** specification of algorithms used
+  # user's configuration, but defaults are inferred
+  algorithms: 
+    random: {}
+
+- name: supernaedo2.2.1
+
+  metadata:
+    # inferred from os
+    user: tsirif
+    datetime: 2017-11-22T20:00:00
+    # from orion.__version__
+    orion_version: 0.1
+    # from `orion`'s args
+    user_script: full_path/main.py
+    # from `orion`'s args
+    user_args: ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])"]
+    # from user's vsc, e.g. git
+    user_vcs: git
+    user_version: ~
+    user_commit_hash: as5f7asf5asfa7sf
+
+  refers:
+    root_id: supernaedo2
+    parent_id: supernaedo2.2
+    adapter:
+      - of_type: algorithmchange
+
+  # orion's configuration
+  pool_size: 2
+  max_trials: 1000
+
+  # functional info
+  status: pending  # pending, done, broken
+
+  # TODO hack in fixtures since we can't define another valid algorithm as we only have random.
+  algorithms:
+    random: {}
+
 ---
 
 # Example of entries in `trials` collection
@@ -291,6 +580,321 @@
     - name: /decoding_layer
       type: categorical
       value: rnn
+
+# Should pass the adapter
+- experiment: supernaedo2
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 21
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding_layer
+      type: categorical
+      value: gru
+    - name: /decoding_layer
+      type: categorical
+      value: gru
+
+# Should be filtered out by adapter
+- experiment: supernaedo2
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 6
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding_layer
+      type: categorical
+      value: rnn
+    - name: /decoding_layer
+      type: categorical
+      value: rnn
+
+- experiment: supernaedo2.1
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 11
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding_layer
+      type: categorical
+      value: rnn
+
+# Should pass with 2.1
+- experiment: supernaedo2
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 5
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding_layer
+      type: categorical
+      value: rnn
+    - name: /decoding_layer
+      type: categorical
+      value: lstm_with_attention
+
+- experiment: supernaedo2.2
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 17
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding_layer
+      type: categorical
+      value: rnn
+
+- experiment: supernaedo2.3
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 20
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding
+      type: categorical
+      value: rnn
+    - name: /decoding_layer
+      type: categorical
+      value: gru
+
+# Should not pass because of encoding lstm
+- experiment: supernaedo2.3
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 10
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding
+      type: categorical
+      value: lstm
+    - name: /decoding_layer
+      type: categorical
+      value: lstm_with_attention
+
+# Should not pass because of decoding_layer gru
+- experiment: supernaedo2.3
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 18
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding
+      type: categorical
+      value: rnn
+    - name: /decoding_layer
+      type: categorical
+      value: gru
+
+# Should pass
+- experiment: supernaedo2.3
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 19
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding
+      type: categorical
+      value: rnn
+    - name: /decoding_layer
+      type: categorical
+      value: lstm_with_attention
+
+# Should not pass to parent because of encoding lstm_with_attention
+- experiment: supernaedo2.3.1
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 2
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding
+      type: categorical
+      value: lstm_with_attention
+
+# Should pass to parent
+- experiment: supernaedo2.3.1
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 2
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding
+      type: categorical
+      value: rnn
+
+- experiment: supernaedo2.3.1.1
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 2
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding
+      type: categorical
+      value: rnn
+
+- experiment: supernaedo2.3.1.2
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 2
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding
+      type: categorical
+      value: rnn
+
+- experiment: supernaedo2.3.1.3
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 2
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding
+      type: categorical
+      value: rnn
+
+- experiment: supernaedo2.2.1
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 2
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding_layer
+      type: categorical
+      value: rnn
+
 ---
 
 # Example of entries in `workers` collection

--- a/tests/unittests/core/experiment.yaml
+++ b/tests/unittests/core/experiment.yaml
@@ -12,7 +12,7 @@
     user: tsirif
     datetime: 2017-11-22T20:00:00
     # from orion.__version__
-    orion_version: 0.1
+    orion_version: XYZ
     # from `orion`'s args
     user_script: full_path/main.py
     # from `orion`'s args
@@ -53,7 +53,7 @@
   metadata:
     user: tsirif
     datetime: 2017-11-22T21:00:00
-    orion_version: 0.1
+    orion_version: XYZ
     user_script: full_path/ieeeela.py
     user_args: ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])", "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"]
     user_vcs: git
@@ -81,7 +81,7 @@
   metadata:
     user: tsirif
     datetime: 2017-11-22T21:00:00
-    orion_version: 0.1
+    orion_version: XYZ
     user_script: full_path/ieeeela.py
     user_args: ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])", "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"]
     user_vcs: git
@@ -109,7 +109,7 @@
   metadata:
     user: dendi
     datetime: 2017-11-22T20:00:00
-    orion_version: 0.1
+    orion_version: XYZ
     user_script: full_path/main.py
     user_args: ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])", "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"]
     user_vcs: git

--- a/tests/unittests/core/experiment.yaml
+++ b/tests/unittests/core/experiment.yaml
@@ -76,6 +76,34 @@
       suspend: False
       done: False
 
+- name: supernaedo4
+
+  metadata:
+    user: tsirif
+    datetime: 2017-11-22T21:00:00
+    orion_version: 0.1
+    user_script: full_path/ieeeela.py
+    user_args: ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])", "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"]
+    user_vcs: git
+    user_version: ~
+    user_commit_hash: as5f7asf5asfa7sf
+  refers:
+    name: supernaedo1
+    user: tsirif
+    params:
+      - name: decoding_layer
+        type: categorical
+        value: gru
+  pool_size: 2
+  max_trials: 1
+  algorithms:
+    dumbalgo:  # this must be logged as `Experiment` would log it, complete specification
+      value: 5
+      scoring: 0
+      judgement: ~
+      suspend: False
+      done: False
+
 - name: supernaedo2
 
   metadata:
@@ -241,6 +269,28 @@
     - name: /decoding_layer
       type: categorical
       value: lstm_with_attention
+
+- experiment: supernaedo4
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 2
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding_layer
+      type: categorical
+      value: rnn
+    - name: /decoding_layer
+      type: categorical
+      value: rnn
 ---
 
 # Example of entries in `workers` collection

--- a/tests/unittests/core/io/conftest.py
+++ b/tests/unittests/core/io/conftest.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Common fixtures and utils for io tests."""
+
+
+import os
+
+import pytest
+
+
+@pytest.fixture()
+def config_file():
+    """Open config file with new config"""
+    file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                             "orion_config.yaml")
+
+    return open(file_path)

--- a/tests/unittests/core/io/conftest.py
+++ b/tests/unittests/core/io/conftest.py
@@ -15,3 +15,21 @@ def config_file():
                              "orion_config.yaml")
 
     return open(file_path)
+
+
+@pytest.fixture()
+def old_config_file():
+    """Open config file with original config from an experiment in db"""
+    file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                             "orion_old_config.yaml")
+
+    return open(file_path)
+
+
+@pytest.fixture()
+def incomplete_config_file():
+    """Open config file with partial database configuration"""
+    file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                             "orion_incomplete_config.yaml")
+
+    return open(file_path)

--- a/tests/unittests/core/io/orion_config.yaml
+++ b/tests/unittests/core/io/orion_config.yaml
@@ -1,0 +1,11 @@
+name: voila_voici
+
+pool_size: 1
+max_trials: 100
+
+algorithms: 'random'
+
+database:
+  type: 'mongodb'
+  name: 'orion_test'
+  host: 'mongodb://user:pass@localhost'

--- a/tests/unittests/core/io/orion_incomplete_config.yaml
+++ b/tests/unittests/core/io/orion_incomplete_config.yaml
@@ -1,0 +1,5 @@
+name: incomplete
+
+database:
+  type: 'incomplete'
+  host: 'mongodb://user:pass@localhost'

--- a/tests/unittests/core/io/orion_old_config.yaml
+++ b/tests/unittests/core/io/orion_old_config.yaml
@@ -1,0 +1,17 @@
+name: voila_voici
+
+pool_size: 2
+max_trials: 1000
+
+algorithms:
+    dumbalgo:
+        done: False
+        judgement: null
+        scoring: 0
+        suspend: False
+        value: 5
+
+database:
+  type: 'mongodb'
+  name: 'orion_test'
+  host: 'mongodb://user:pass@localhost'

--- a/tests/unittests/core/io/test_evc_builder.py
+++ b/tests/unittests/core/io/test_evc_builder.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Collection of tests for :mod:`orion.core.io.evc_builder`."""
+
+
+import pytest
+
+from orion.core.io.evc_builder import (
+    build_tree, build_trimmed_tree, fetch_nodes, trim_tree)
+from orion.core.worker.experiment import ExperimentView
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_fetch_nodes(create_db_instance):
+    """Verify that all nodes from an EVC tree are fetched"""
+    experiment = ExperimentView('supernaedo2.3')
+    nodes = fetch_nodes(experiment.refers['root_id'])
+
+    assert experiment.refers['root_id'] in [n['_id'] for n in nodes]
+    assert len(nodes) == 9
+
+    experiment = ExperimentView('supernaedo2.3.1.1')
+    nodes = fetch_nodes(experiment.refers['root_id'])
+
+    assert experiment.refers['root_id'] in [n['_id'] for n in nodes]
+    assert len(nodes) == 9
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_build_tree(create_db_instance):
+    """Verify that built tree has the proper structure"""
+    experiment = ExperimentView('supernaedo2.3')
+    nodes = fetch_nodes(experiment.refers['root_id'])
+    root_node = build_tree(experiment.refers['root_id'], nodes)
+
+    assert root_node.item == 'supernaedo2'
+    assert root_node.children[0].item == 'supernaedo2.1'
+    assert root_node.children[1].item == 'supernaedo2.2'
+    assert root_node.children[1].children[0].item == 'supernaedo2.2.1'
+    assert root_node.children[2].item == 'supernaedo2.3'
+    assert root_node.children[2].children[0].item == 'supernaedo2.3.1'
+    assert root_node.children[2].children[0].children[0].item == 'supernaedo2.3.1.1'
+    assert root_node.children[2].children[0].children[1].item == 'supernaedo2.3.1.2'
+    assert root_node.children[2].children[0].children[2].item == 'supernaedo2.3.1.3'
+
+    # Make sure there is no duplicate nodes
+    assert len(list(root_node)) == 9
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_trim_tree_self_root_self_leaf(create_db_instance):
+    """Verify that the tree is trimmed only keeping current node"""
+    experiment_name = 'supernaedo2.3'
+    root_name = 'supernaedo2.3'
+    leaf_names = ['supernaedo2.3']
+
+    experiment = ExperimentView(experiment_name)
+    nodes = fetch_nodes(experiment.refers['root_id'])
+    root_node = build_tree(experiment.refers['root_id'], nodes)
+    exp_tree_node = trim_tree(root_node, experiment_name, root_name, leaf_names)
+
+    assert exp_tree_node.item == experiment_name
+    assert len(list(exp_tree_node)) == 1
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_trim_tree_direct_root_self_leaf(create_db_instance):
+    """Verify that the tree is trimmed only keeping parent"""
+    experiment_name = 'supernaedo2.3'
+    root_name = 'supernaedo2'
+    leaf_names = ['supernaedo2.3']
+
+    experiment = ExperimentView(experiment_name)
+    nodes = fetch_nodes(experiment.refers['root_id'])
+    root_node = build_tree(experiment.refers['root_id'], nodes)
+    exp_tree_node = trim_tree(root_node, experiment_name, root_name, leaf_names)
+
+    assert exp_tree_node.item == experiment_name
+    assert exp_tree_node.parent.item == root_name
+    assert len(list(exp_tree_node.root)) == 2
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_trim_tree_deep_root_self_leaf(create_db_instance):
+    """Verify that the tree is trimmed only keeping all parents"""
+    experiment_name = 'supernaedo2.2.1'
+    root_name = 'supernaedo2'
+    leaf_names = ['supernaedo2.2.1']
+
+    experiment = ExperimentView(experiment_name)
+    nodes = fetch_nodes(experiment.refers['root_id'])
+    root_node = build_tree(experiment.refers['root_id'], nodes)
+    exp_tree_node = trim_tree(root_node, experiment_name, root_name, leaf_names)
+
+    assert exp_tree_node.item == experiment_name
+    assert exp_tree_node.parent.parent.item == root_name
+    assert len(list(exp_tree_node.root)) == 3
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_trim_tree_self_root_direct_leaf(create_db_instance):
+    """Verify that the tree is trimmed only keeping child"""
+    experiment_name = 'supernaedo2.3'
+    root_name = 'supernaedo2.3'
+    leaf_names = ['supernaedo2.3.1']
+
+    experiment = ExperimentView(experiment_name)
+    nodes = fetch_nodes(experiment.refers['root_id'])
+    root_node = build_tree(experiment.refers['root_id'], nodes)
+    exp_tree_node = trim_tree(root_node, experiment_name, root_name, leaf_names)
+
+    assert exp_tree_node.item == experiment_name
+    assert exp_tree_node.children[0].item == leaf_names[0]
+    assert len(list(exp_tree_node.root)) == 2
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_trim_tree_self_root_deep_leaf(create_db_instance):
+    """Verify that the tree is trimmed only keeping path to a leaf"""
+    experiment_name = 'supernaedo2.3'
+    root_name = 'supernaedo2.3'
+    leaf_names = ['supernaedo2.3.1.2']
+
+    experiment = ExperimentView(experiment_name)
+    nodes = fetch_nodes(experiment.refers['root_id'])
+    root_node = build_tree(experiment.refers['root_id'], nodes)
+    exp_tree_node = trim_tree(root_node, experiment_name, root_name, leaf_names)
+
+    assert exp_tree_node.item == experiment_name
+    assert exp_tree_node.children[0].children[0].item == leaf_names[0]
+    assert len(list(exp_tree_node.root)) == 3
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_trim_tree_self_root_multi_deep_leaf(create_db_instance):
+    """Verify that the tree is trimmed only keeping path to multiple leafs"""
+    experiment_name = 'supernaedo2.3'
+    root_name = 'supernaedo2.3'
+    leaf_names = ['supernaedo2.3.1.1', 'supernaedo2.3.1.2']
+
+    experiment = ExperimentView(experiment_name)
+    nodes = fetch_nodes(experiment.refers['root_id'])
+    root_node = build_tree(experiment.refers['root_id'], nodes)
+    exp_tree_node = trim_tree(root_node, experiment_name, root_name, leaf_names)
+
+    assert exp_tree_node.item == experiment_name
+    assert exp_tree_node.children[0].children[0].item == leaf_names[0]
+    assert exp_tree_node.children[0].children[1].item == leaf_names[1]
+    assert len(list(exp_tree_node.root)) == 4
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_trim_tree_non_connected_root(create_db_instance):
+    """Verify the function raises an error if specified root is not connected to experiment"""
+    experiment_name = 'supernaedo2.2.1'
+    root_name = 'supernaedo2.3'
+    leaf_names = ['supernaedo2.2.1']
+
+    experiment = ExperimentView(experiment_name)
+    nodes = fetch_nodes(experiment.refers['root_id'])
+    root_node = build_tree(experiment.refers['root_id'], nodes)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        trim_tree(root_node, experiment_name, root_name, leaf_names)
+    assert "Some experiments were not found: {'supernaedo2.3'}" in str(exc_info.value)
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_trim_tree_self_root_non_connected_leaf(create_db_instance):
+    """Verify the function raises an error if specified leaf is not connected to experiment"""
+    experiment_name = 'supernaedo2.3'
+    root_name = 'supernaedo2.3'
+    leaf_names = ['supernaedo2.3.1.1', 'supernaedo2.2.1']
+
+    experiment = ExperimentView(experiment_name)
+    nodes = fetch_nodes(experiment.refers['root_id'])
+    root_node = build_tree(experiment.refers['root_id'], nodes)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        trim_tree(root_node, experiment_name, root_name, leaf_names)
+    assert "Some experiments were not found: {'supernaedo2.2.1'}" in str(exc_info.value)
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_trim_tree_self_root_multi_depth_leaf(create_db_instance):
+    """Verify that the tree is trimmed only keeping path to multiple leafs (of different depth)"""
+    experiment_name = 'supernaedo2'
+    root_name = 'supernaedo2'
+    leaf_names = ['supernaedo2.3.1.1', 'supernaedo2.2.1']
+
+    experiment = ExperimentView(experiment_name)
+    nodes = fetch_nodes(experiment.refers['root_id'])
+    root_node = build_tree(experiment.refers['root_id'], nodes)
+    exp_tree_node = trim_tree(root_node, experiment_name, root_name, leaf_names)
+
+    assert exp_tree_node.item == experiment_name
+    assert exp_tree_node.children[0].children[0].item == leaf_names[1]
+    assert exp_tree_node.children[1].children[0].children[0].item == leaf_names[0]
+    # 2
+    # |      \
+    # 2.2,   2.3
+    # |       |
+    # 2.2.1  2.3.1
+    #         |
+    #        2.3.1.1
+    assert len(list(exp_tree_node.root)) == 6
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_trim_tree_direct_root_direct_leaf(create_db_instance):
+    """Verify that the tree is trimmed only keeping parent and leaf"""
+    experiment_name = 'supernaedo2.2'
+    root_name = 'supernaedo2'
+    leaf_names = ['supernaedo2.2.1']
+
+    experiment = ExperimentView(experiment_name)
+    nodes = fetch_nodes(experiment.refers['root_id'])
+    root_node = build_tree(experiment.refers['root_id'], nodes)
+    exp_tree_node = trim_tree(root_node, experiment_name, root_name, leaf_names)
+
+    assert exp_tree_node.item == experiment_name
+    assert exp_tree_node.parent.item == root_name
+    assert exp_tree_node.children[0].item == leaf_names[0]
+    # 2
+    # |
+    # 2.2
+    # |
+    # 2.2.1
+    assert len(list(exp_tree_node.root)) == 3
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_trim_tree_direct_root_deep_leaf(create_db_instance):
+    """Verify that the tree is trimmed only keeping parent and path to leaf"""
+    experiment_name = 'supernaedo2.3'
+    root_name = 'supernaedo2'
+    leaf_names = ['supernaedo2.3.1.2']
+
+    experiment = ExperimentView(experiment_name)
+    nodes = fetch_nodes(experiment.refers['root_id'])
+    root_node = build_tree(experiment.refers['root_id'], nodes)
+    exp_tree_node = trim_tree(root_node, experiment_name, root_name, leaf_names)
+
+    assert exp_tree_node.item == experiment_name
+    assert exp_tree_node.parent.item == root_name
+    assert exp_tree_node.children[0].children[0].item == leaf_names[0]
+    # 2
+    # |
+    # 2.3
+    # |
+    # 2.3.1
+    # |
+    # 2.3.1.2
+    assert len(list(exp_tree_node.root)) == 4
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_trim_tree_deep_root_direct_leaf(create_db_instance):
+    """Verify that the tree is trimmed only keeping path to root and leaf"""
+    experiment_name = 'supernaedo2.3.1'
+    root_name = 'supernaedo2'
+    leaf_names = ['supernaedo2.3.1.1']
+
+    experiment = ExperimentView(experiment_name)
+    nodes = fetch_nodes(experiment.refers['root_id'])
+    root_node = build_tree(experiment.refers['root_id'], nodes)
+    exp_tree_node = trim_tree(root_node, experiment_name, root_name, leaf_names)
+
+    assert exp_tree_node.item == experiment_name
+    assert exp_tree_node.parent.parent.item == root_name
+    assert exp_tree_node.children[0].item == leaf_names[0]
+    # 2
+    # |
+    # 2.3
+    # |
+    # 2.3.1
+    # |
+    # 2.3.1.1
+    assert len(list(exp_tree_node.root)) == 4
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_trim_tree_no_root(create_db_instance):
+    """Verify that the tree is not trimmed at root"""
+    experiment_name = 'supernaedo2.3'
+    root_name = None
+    leaf_names = ['supernaedo2.3.1.1']
+
+    experiment = ExperimentView(experiment_name)
+    nodes = fetch_nodes(experiment.refers['root_id'])
+    root_node = build_tree(experiment.refers['root_id'], nodes)
+    exp_tree_node = trim_tree(root_node, experiment_name, root_name, leaf_names)
+
+    assert exp_tree_node.item == experiment_name
+    assert exp_tree_node.parent.item == 'supernaedo2'
+    assert exp_tree_node.children[0].children[0].item == leaf_names[0]
+    # 2
+    # |
+    # 2.3
+    # |
+    # 2.3.1
+    # |
+    # 2.3.1.1
+    assert len(list(exp_tree_node.root)) == 4
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_trim_tree_no_leaf(create_db_instance):
+    """Verify that the tree is not trimmed at leafs"""
+    experiment_name = 'supernaedo2.3'
+    root_name = 'supernaedo2'
+    leaf_names = []
+
+    experiment = ExperimentView(experiment_name)
+    nodes = fetch_nodes(experiment.refers['root_id'])
+    root_node = build_tree(experiment.refers['root_id'], nodes)
+    exp_tree_node = trim_tree(root_node, experiment_name, root_name, leaf_names)
+
+    assert exp_tree_node.item == experiment_name
+    assert exp_tree_node.parent.item == root_name
+    assert exp_tree_node.children[0].children[0].item == 'supernaedo2.3.1.1'
+    assert exp_tree_node.children[0].children[1].item == 'supernaedo2.3.1.2'
+    assert exp_tree_node.children[0].children[2].item == 'supernaedo2.3.1.3'
+    # 2
+    # |
+    # 2.3
+    # |
+    # 2.3.1
+    # |        \         \
+    # 2.3.1.1  2.3.1.2  2.3.1.3
+    assert len(list(exp_tree_node.root)) == 6
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_build_trimmed_tree(create_db_instance):
+    """Test trimmed tree converted to experiment nodes"""
+    experiment_name = 'supernaedo2.3'
+    root_name = None
+    leaf_names = []
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.parent.item.name == 'supernaedo2'
+    assert exp_node.children[0].children[0].item.name == 'supernaedo2.3.1.1'
+    assert exp_node.children[0].children[1].item.name == 'supernaedo2.3.1.2'
+    assert exp_node.children[0].children[2].item.name == 'supernaedo2.3.1.3'
+    # 2
+    # |
+    # 2.3
+    # |
+    # 2.3.1
+    # |        \         \
+    # 2.3.1.1  2.3.1.2  2.3.1.3
+    assert len(list(exp_node.root)) == 6
+
+
+@pytest.mark.usefixtures("refers_id_substitution")
+def test_build_trimmed_tree_from_children_children(create_db_instance):
+    """Test trimmed tree converted to experiment nodes with children experiment"""
+    experiment_name = 'supernaedo2.3.1'
+    root_name = 'supernaedo2'
+    leaf_names = ['supernaedo2.3.1']
+
+    experiment = ExperimentView(experiment_name)
+    exp_node = build_trimmed_tree(experiment, root_name, leaf_names)
+
+    assert exp_node.item.name == experiment_name
+    assert exp_node.parent.parent.item.name == root_name
+    assert len(exp_node.children) == 0
+    # 2
+    # |
+    # 2.3
+    # |
+    # 2.3.1
+    assert len(list(exp_node.root)) == 3

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -97,9 +97,6 @@ def test_fetch_full_config_new_config(config_file, exp_config, random_dt):
 
     assert full_config['name'] == exp_config[0][0]['name']
     assert full_config['refers'] == exp_config[0][0]['refers']
-    assert full_config['metadata']['datetime'] == exp_config[0][0]['metadata']['datetime']
-    assert full_config['metadata'] == exp_config[0][0]['metadata']
-    assert full_config['metadata'] == exp_config[0][0]['metadata']
     assert full_config['metadata'] == exp_config[0][0]['metadata']
     assert full_config['pool_size'] == cmdconfig['pool_size']
     assert full_config['max_trials'] == cmdconfig['max_trials']
@@ -143,8 +140,8 @@ def test_fetch_full_config_no_hit(config_file, exp_config, random_dt):
     assert full_config['max_trials'] == 100
     assert full_config['name'] == 'supernaekei'
     assert full_config['pool_size'] == 1
-    assert full_config['metadata']['datetime'] == random_dt
     assert full_config['metadata']['user'] == 'tsirif'
+    assert 'datetime' not in full_config['metadata']
     assert 'refers' not in full_config
     assert 'status' not in full_config
 

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -42,18 +42,18 @@ def test_fetch_local_config_from_incomplete_config(incomplete_config_file):
 
 
 @pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
-def test_fetch_db_config_no_hit(config_file, random_dt):
-    """Verify that fetch_db_config returns an empty dict when the experiment is not in db"""
+def test_fetch_config_from_db_no_hit(config_file, random_dt):
+    """Verify that fetch_config_from_db returns an empty dict when the experiment is not in db"""
     cmdargs = {'name': 'supernaekei', 'config': config_file}
-    db_config = ExperimentBuilder().fetch_db_config(cmdargs)
+    db_config = ExperimentBuilder().fetch_config_from_db(cmdargs)
     assert db_config == {}
 
 
 @pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
-def test_fetch_db_config_hit(config_file, exp_config):
+def test_fetch_config_from_db_hit(config_file, exp_config, random_dt):
     """Verify db config when experiment is in db"""
     cmdargs = {'name': 'supernaedo2', 'config': config_file}
-    db_config = ExperimentBuilder().fetch_db_config(cmdargs)
+    db_config = ExperimentBuilder().fetch_config_from_db(cmdargs)
 
     assert db_config['name'] == exp_config[0][0]['name']
     assert db_config['refers'] == exp_config[0][0]['refers']

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -142,7 +142,7 @@ def test_build_view_from(config_file, create_db_instance, exp_config, random_dt)
     assert exp_view._experiment._db._database is create_db_instance
     assert exp_view._id == exp_config[0][0]['_id']
     assert exp_view.name == exp_config[0][0]['name']
-    assert exp_view.refers == exp_config[0][0]['refers']
+    assert exp_view.configuration['refers'] == exp_config[0][0]['refers']
     assert exp_view.metadata == exp_config[0][0]['metadata']
     assert exp_view._experiment._last_fetched == exp_config[0][0]['metadata']['datetime']
     assert exp_view.pool_size == exp_config[0][0]['pool_size']
@@ -165,7 +165,7 @@ def test_build_from_no_hit(config_file, create_db_instance, exp_config, random_d
     assert exp._init_done is True
     assert exp._db is create_db_instance
     assert exp.name == cmdargs['name']
-    assert exp.refers is None
+    assert exp.configuration['refers'] == {'adapter': [], 'parent_id': None, 'root_id': exp._id}
     assert exp.metadata['datetime'] == random_dt
     assert exp.metadata['user'] == 'tsirif'
     assert exp.metadata['user_args'] == cmdargs['user_args']
@@ -192,7 +192,7 @@ def test_build_from_hit(old_config_file, create_db_instance, exp_config):
     assert exp._db is create_db_instance
     assert exp._id == exp_config[0][0]['_id']
     assert exp.name == exp_config[0][0]['name']
-    assert exp.refers == exp_config[0][0]['refers']
+    assert exp.configuration['refers'] == exp_config[0][0]['refers']
     assert exp.metadata == exp_config[0][0]['metadata']
     assert exp._last_fetched == exp_config[0][0]['metadata']['datetime']
     assert exp.pool_size == exp_config[0][0]['pool_size']
@@ -216,7 +216,7 @@ def test_build_from_config_no_hit(config_file, create_db_instance, exp_config, r
     assert exp._init_done is True
     assert exp._db is create_db_instance
     assert exp.name == cmdargs['name']
-    assert exp.refers is None
+    assert exp.configuration['refers'] == {'adapter': [], 'parent_id': None, 'root_id': exp._id}
     assert exp.metadata['datetime'] == random_dt
     assert exp.metadata['user'] == 'tsirif'
     assert exp.metadata['user_args'] == cmdargs['user_args']
@@ -246,7 +246,7 @@ def test_build_from_config_hit(old_config_file, create_db_instance, exp_config):
     assert exp._db is create_db_instance
     assert exp._id == exp_config[0][0]['_id']
     assert exp.name == exp_config[0][0]['name']
-    assert exp.refers == exp_config[0][0]['refers']
+    assert exp.configuration['refers'] == exp_config[0][0]['refers']
     assert exp.metadata == exp_config[0][0]['metadata']
     assert exp._last_fetched == exp_config[0][0]['metadata']['datetime']
     assert exp.pool_size == exp_config[0][0]['pool_size']

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -60,7 +60,6 @@ def test_fetch_config_from_db_hit(config_file, exp_config, random_dt):
     assert db_config['metadata'] == exp_config[0][0]['metadata']
     assert db_config['pool_size'] == exp_config[0][0]['pool_size']
     assert db_config['max_trials'] == exp_config[0][0]['max_trials']
-    assert db_config['status'] == exp_config[0][0]['status']
     assert db_config['algorithms'] == exp_config[0][0]['algorithms']
 
 
@@ -121,7 +120,6 @@ def test_fetch_full_config_no_hit(config_file, exp_config, random_dt):
     assert full_config['metadata']['user'] == 'tsirif'
     assert 'datetime' not in full_config['metadata']
     assert 'refers' not in full_config
-    assert 'status' not in full_config
 
 
 @pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
@@ -149,7 +147,6 @@ def test_build_view_from(config_file, create_db_instance, exp_config, random_dt)
     assert exp_view._experiment._last_fetched == exp_config[0][0]['metadata']['datetime']
     assert exp_view.pool_size == exp_config[0][0]['pool_size']
     assert exp_view.max_trials == exp_config[0][0]['max_trials']
-    assert exp_view.status == exp_config[0][0]['status']
     assert exp_view.algorithms.configuration == exp_config[0][0]['algorithms']
 
 
@@ -175,7 +172,6 @@ def test_build_from_no_hit(config_file, create_db_instance, exp_config, random_d
     assert exp._last_fetched == random_dt
     assert exp.pool_size == 1
     assert exp.max_trials == 100
-    assert exp.status == 'pending'
     assert exp.algorithms.configuration == {'random': {}}
 
 
@@ -201,7 +197,6 @@ def test_build_from_hit(old_config_file, create_db_instance, exp_config):
     assert exp._last_fetched == exp_config[0][0]['metadata']['datetime']
     assert exp.pool_size == exp_config[0][0]['pool_size']
     assert exp.max_trials == exp_config[0][0]['max_trials']
-    assert exp.status == exp_config[0][0]['status']
     assert exp.algorithms.configuration == exp_config[0][0]['algorithms']
 
 
@@ -228,7 +223,7 @@ def test_build_from_config_no_hit(config_file, create_db_instance, exp_config, r
     assert exp._last_fetched == random_dt
     assert exp.pool_size == 1
     assert exp.max_trials == 100
-    assert exp.status == 'pending'
+    assert not exp.is_done
     assert exp.algorithms.configuration == {'random': {}}
 
 
@@ -256,5 +251,4 @@ def test_build_from_config_hit(old_config_file, create_db_instance, exp_config):
     assert exp._last_fetched == exp_config[0][0]['metadata']['datetime']
     assert exp.pool_size == exp_config[0][0]['pool_size']
     assert exp.max_trials == exp_config[0][0]['max_trials']
-    assert exp.status == exp_config[0][0]['status']
     assert exp.algorithms.configuration == exp_config[0][0]['algorithms']

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -7,18 +7,6 @@ import pytest
 from orion.core.io.experiment_builder import ExperimentBuilder
 
 
-@pytest.fixture
-def version_01(monkeypatch):
-    """Force orion version 0.1 on output of ExperimentBuilder.fetch_full_config"""
-    non_patched_fetch_full_config = ExperimentBuilder.fetch_full_config
-
-    def fetch_full_config(self, cmdargs):
-        full_config = non_patched_fetch_full_config(self, cmdargs)
-        full_config['metadata']['orion_version'] = 0.1
-        return full_config
-    monkeypatch.setattr(ExperimentBuilder, "fetch_full_config", fetch_full_config)
-
-
 @pytest.mark.usefixtures("clean_db")
 def test_fetch_local_config(config_file):
     """Test local config (default, env_vars, cmdconfig, cmdargs)"""
@@ -53,9 +41,7 @@ def test_fetch_local_config_from_incomplete_config(incomplete_config_file):
     assert local_config['pool_size'] == 10
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
 def test_fetch_db_config_no_hit(config_file, random_dt):
     """Verify that fetch_db_config returns an empty dict when the experiment is not in db"""
     cmdargs = {'name': 'supernaekei', 'config': config_file}
@@ -63,9 +49,7 @@ def test_fetch_db_config_no_hit(config_file, random_dt):
     assert db_config == {}
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
 def test_fetch_db_config_hit(config_file, exp_config):
     """Verify db config when experiment is in db"""
     cmdargs = {'name': 'supernaedo2', 'config': config_file}
@@ -80,9 +64,7 @@ def test_fetch_db_config_hit(config_file, exp_config):
     assert db_config['algorithms'] == exp_config[0][0]['algorithms']
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
 def test_fetch_full_config_new_config(config_file, exp_config, random_dt):
     """Verify full config with new config (causing branch)"""
     cmdargs = {'name': 'supernaedo2',
@@ -103,10 +85,8 @@ def test_fetch_full_config_new_config(config_file, exp_config, random_dt):
     assert full_config['algorithms'] == cmdconfig['algorithms']
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
-def test_fetch_full_config_old_config(old_config_file, exp_config):
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
+def test_fetch_full_config_old_config(old_config_file, exp_config, random_dt):
     """Verify full config with old config (not causing branch)"""
     cmdargs = {'name': 'supernaedo2',
                'config': old_config_file,
@@ -127,9 +107,7 @@ def test_fetch_full_config_old_config(old_config_file, exp_config):
     assert full_config['algorithms'] == cmdconfig['algorithms']
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
 def test_fetch_full_config_no_hit(config_file, exp_config, random_dt):
     """Verify full config when experiment not in db"""
     cmdargs = {'name': 'supernaekei', 'config': config_file}
@@ -146,9 +124,7 @@ def test_fetch_full_config_no_hit(config_file, exp_config, random_dt):
     assert 'status' not in full_config
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
 def test_build_view_from_no_hit(config_file, create_db_instance, exp_config):
     """Try building experiment view when not in db"""
     cmdargs = {'name': 'supernaekei', 'config': config_file}
@@ -158,10 +134,8 @@ def test_build_view_from_no_hit(config_file, create_db_instance, exp_config):
     assert "No experiment with given name 'supernaekei' for user 'tsirif'" in str(exc_info.value)
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
-def test_build_view_from(config_file, create_db_instance, exp_config):
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
+def test_build_view_from(config_file, create_db_instance, exp_config, random_dt):
     """Try building experiment view when in db"""
     cmdargs = {'name': 'supernaedo2', 'config': config_file}
     exp_view = ExperimentBuilder().build_view_from(cmdargs)
@@ -179,9 +153,7 @@ def test_build_view_from(config_file, create_db_instance, exp_config):
     assert exp_view.algorithms.configuration == exp_config[0][0]['algorithms']
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
 def test_build_from_no_hit(config_file, create_db_instance, exp_config, random_dt):
     """Try building experiment when not in db"""
     cmdargs = {'name': 'supernaekei', 'config': config_file,
@@ -207,10 +179,7 @@ def test_build_from_no_hit(config_file, create_db_instance, exp_config, random_d
     assert exp.algorithms.configuration == {'random': {}}
 
 
-@pytest.mark.usefixtures("version_01")
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("version_XYZ", "clean_db", "null_db_instances", "with_user_tsirif")
 def test_build_from_hit(old_config_file, create_db_instance, exp_config):
     """Try building experiment when in db (no branch)"""
     cmdargs = {'name': 'supernaedo2',
@@ -236,10 +205,7 @@ def test_build_from_hit(old_config_file, create_db_instance, exp_config):
     assert exp.algorithms.configuration == exp_config[0][0]['algorithms']
 
 
-@pytest.mark.usefixtures("version_01")
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("version_XYZ", "clean_db", "null_db_instances", "with_user_tsirif")
 def test_build_from_config_no_hit(config_file, create_db_instance, exp_config, random_dt):
     """Try building experiment from config when not in db"""
     cmdargs = {'name': 'supernaekei', 'config': config_file,
@@ -266,9 +232,7 @@ def test_build_from_config_no_hit(config_file, create_db_instance, exp_config, r
     assert exp.algorithms.configuration == {'random': {}}
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
 def test_build_from_config_hit(old_config_file, create_db_instance, exp_config):
     """Try building experiment from config when in db (no branch)"""
     cmdargs = {'name': 'supernaedo2',

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Example usage and tests for :mod:`orion.core.io.experiment_builder`."""
+
+import pytest
+
+from orion.core.io.experiment_builder import ExperimentBuilder
+
+
+@pytest.fixture
+def version_01(monkeypatch):
+    """Force orion version 0.1 on output of ExperimentBuilder.fetch_full_config"""
+    non_patched_fetch_full_config = ExperimentBuilder.fetch_full_config
+
+    def fetch_full_config(self, cmdargs):
+        full_config = non_patched_fetch_full_config(self, cmdargs)
+        full_config['metadata']['orion_version'] = 0.1
+        return full_config
+    monkeypatch.setattr(ExperimentBuilder, "fetch_full_config", fetch_full_config)
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_fetch_local_config(config_file):
+    """Test local config (default, env_vars, cmdconfig, cmdargs)"""
+    cmdargs = {"config": config_file}
+    local_config = ExperimentBuilder().fetch_local_config(cmdargs)
+
+    assert local_config['algorithms'] == 'random'
+    assert local_config['database']['host'] == 'mongodb://user:pass@localhost'
+    assert local_config['database']['name'] == 'orion_test'
+    assert local_config['database']['type'] == 'mongodb'
+    assert local_config['max_trials'] == 100
+    assert local_config['name'] == 'voila_voici'
+    assert local_config['pool_size'] == 1
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_fetch_local_config_from_incomplete_config(incomplete_config_file):
+    """Test local config with incomplete user configuration file
+    (default, env_vars, cmdconfig, cmdargs)
+
+    This is to ensure merge_configs update properly the subconfigs
+    """
+    cmdargs = {"config": incomplete_config_file}
+    local_config = ExperimentBuilder().fetch_local_config(cmdargs)
+
+    assert local_config['algorithms'] == 'random'
+    assert local_config['database']['host'] == 'mongodb://user:pass@localhost'
+    assert local_config['database']['name'] == 'orion'
+    assert local_config['database']['type'] == 'incomplete'
+    assert local_config['max_trials'] == float('inf')
+    assert local_config['name'] == 'incomplete'
+    assert local_config['pool_size'] == 10
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_fetch_db_config_no_hit(config_file, random_dt):
+    """Verify that fetch_db_config returns an empty dict when the experiment is not in db"""
+    cmdargs = {'name': 'supernaekei', 'config': config_file}
+    db_config = ExperimentBuilder().fetch_db_config(cmdargs)
+    assert db_config == {}
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_fetch_db_config_hit(config_file, exp_config):
+    """Verify db config when experiment is in db"""
+    cmdargs = {'name': 'supernaedo2', 'config': config_file}
+    db_config = ExperimentBuilder().fetch_db_config(cmdargs)
+
+    assert db_config['name'] == exp_config[0][0]['name']
+    assert db_config['refers'] == exp_config[0][0]['refers']
+    assert db_config['metadata'] == exp_config[0][0]['metadata']
+    assert db_config['pool_size'] == exp_config[0][0]['pool_size']
+    assert db_config['max_trials'] == exp_config[0][0]['max_trials']
+    assert db_config['status'] == exp_config[0][0]['status']
+    assert db_config['algorithms'] == exp_config[0][0]['algorithms']
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_fetch_full_config_new_config(config_file, exp_config, random_dt):
+    """Verify full config with new config (causing branch)"""
+    cmdargs = {'name': 'supernaedo2',
+               'config': config_file,
+               'user_args': ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])",
+                             "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"],
+               'user_script': 'full_path/main.py'}
+    full_config = ExperimentBuilder().fetch_full_config(cmdargs)
+    cmdconfig = ExperimentBuilder().fetch_file_config(cmdargs)
+
+    full_config['metadata']['orion_version'] = exp_config[0][0]['metadata']['orion_version']
+
+    assert full_config['name'] == exp_config[0][0]['name']
+    assert full_config['refers'] == exp_config[0][0]['refers']
+    assert full_config['metadata']['datetime'] == exp_config[0][0]['metadata']['datetime']
+    assert full_config['metadata'] == exp_config[0][0]['metadata']
+    assert full_config['metadata'] == exp_config[0][0]['metadata']
+    assert full_config['metadata'] == exp_config[0][0]['metadata']
+    assert full_config['pool_size'] == cmdconfig['pool_size']
+    assert full_config['max_trials'] == cmdconfig['max_trials']
+    assert full_config['algorithms'] == cmdconfig['algorithms']
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_fetch_full_config_old_config(old_config_file, exp_config):
+    """Verify full config with old config (not causing branch)"""
+    cmdargs = {'name': 'supernaedo2',
+               'config': old_config_file,
+               'user_args': ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])",
+                             "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"],
+               'user_script': 'full_path/main.py'}
+
+    full_config = ExperimentBuilder().fetch_full_config(cmdargs)
+    cmdconfig = ExperimentBuilder().fetch_file_config(cmdargs)
+
+    full_config['metadata']['orion_version'] = exp_config[0][0]['metadata']['orion_version']
+
+    assert full_config['name'] == exp_config[0][0]['name']
+    assert full_config['refers'] == exp_config[0][0]['refers']
+    assert full_config['metadata'] == exp_config[0][0]['metadata']
+    assert full_config['pool_size'] == cmdconfig['pool_size']
+    assert full_config['max_trials'] == cmdconfig['max_trials']
+    assert full_config['algorithms'] == cmdconfig['algorithms']
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_fetch_full_config_no_hit(config_file, exp_config, random_dt):
+    """Verify full config when experiment not in db"""
+    cmdargs = {'name': 'supernaekei', 'config': config_file}
+    full_config = ExperimentBuilder().fetch_full_config(cmdargs)
+
+    assert full_config['name'] == 'supernaekei'
+    assert full_config['algorithms'] == 'random'
+    assert full_config['max_trials'] == 100
+    assert full_config['name'] == 'supernaekei'
+    assert full_config['pool_size'] == 1
+    assert full_config['metadata']['datetime'] == random_dt
+    assert full_config['metadata']['user'] == 'tsirif'
+    assert 'refers' not in full_config
+    assert 'status' not in full_config
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_build_view_from_no_hit(config_file, create_db_instance, exp_config):
+    """Try building experiment view when not in db"""
+    cmdargs = {'name': 'supernaekei', 'config': config_file}
+
+    with pytest.raises(ValueError) as exc_info:
+        ExperimentBuilder().build_view_from(cmdargs)
+    assert "No experiment with given name 'supernaekei' for user 'tsirif'" in str(exc_info.value)
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_build_view_from(config_file, create_db_instance, exp_config):
+    """Try building experiment view when in db"""
+    cmdargs = {'name': 'supernaedo2', 'config': config_file}
+    exp_view = ExperimentBuilder().build_view_from(cmdargs)
+
+    assert exp_view._experiment._init_done is True
+    assert exp_view._experiment._db._database is create_db_instance
+    assert exp_view._id == exp_config[0][0]['_id']
+    assert exp_view.name == exp_config[0][0]['name']
+    assert exp_view.refers == exp_config[0][0]['refers']
+    assert exp_view.metadata == exp_config[0][0]['metadata']
+    assert exp_view._experiment._last_fetched == exp_config[0][0]['metadata']['datetime']
+    assert exp_view.pool_size == exp_config[0][0]['pool_size']
+    assert exp_view.max_trials == exp_config[0][0]['max_trials']
+    assert exp_view.status == exp_config[0][0]['status']
+    assert exp_view.algorithms.configuration == exp_config[0][0]['algorithms']
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_build_from_no_hit(config_file, create_db_instance, exp_config, random_dt):
+    """Try building experiment when not in db"""
+    cmdargs = {'name': 'supernaekei', 'config': config_file,
+               'user_args': ['x~uniform(0,10)']}
+
+    with pytest.raises(ValueError) as exc_info:
+        ExperimentBuilder().build_view_from(cmdargs)
+    assert "No experiment with given name 'supernaekei' for user 'tsirif'" in str(exc_info.value)
+
+    exp = ExperimentBuilder().build_from(cmdargs)
+
+    assert exp._init_done is True
+    assert exp._db is create_db_instance
+    assert exp.name == cmdargs['name']
+    assert exp.refers is None
+    assert exp.metadata['datetime'] == random_dt
+    assert exp.metadata['user'] == 'tsirif'
+    assert exp.metadata['user_args'] == cmdargs['user_args']
+    assert exp._last_fetched == random_dt
+    assert exp.pool_size == 1
+    assert exp.max_trials == 100
+    assert exp.status == 'pending'
+    assert exp.algorithms.configuration == {'random': {}}
+
+
+@pytest.mark.usefixtures("version_01")
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_build_from_hit(old_config_file, create_db_instance, exp_config):
+    """Try building experiment when in db (no branch)"""
+    cmdargs = {'name': 'supernaedo2',
+               'config': old_config_file,
+               'user_args': ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])",
+                             "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"],
+               'user_script': 'full_path/main.py'}
+
+    # Test that experiment already exists
+    ExperimentBuilder().build_view_from(cmdargs)
+    exp = ExperimentBuilder().build_from(cmdargs)
+
+    assert exp._init_done is True
+    assert exp._db is create_db_instance
+    assert exp._id == exp_config[0][0]['_id']
+    assert exp.name == exp_config[0][0]['name']
+    assert exp.refers == exp_config[0][0]['refers']
+    assert exp.metadata == exp_config[0][0]['metadata']
+    assert exp._last_fetched == exp_config[0][0]['metadata']['datetime']
+    assert exp.pool_size == exp_config[0][0]['pool_size']
+    assert exp.max_trials == exp_config[0][0]['max_trials']
+    assert exp.status == exp_config[0][0]['status']
+    assert exp.algorithms.configuration == exp_config[0][0]['algorithms']
+
+
+@pytest.mark.usefixtures("version_01")
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_build_from_config_no_hit(config_file, create_db_instance, exp_config, random_dt):
+    """Try building experiment from config when not in db"""
+    cmdargs = {'name': 'supernaekei', 'config': config_file,
+               'user_args': ['x~uniform(0,10)']}
+
+    with pytest.raises(ValueError) as exc_info:
+        ExperimentBuilder().build_view_from(cmdargs)
+    assert "No experiment with given name 'supernaekei' for user 'tsirif'" in str(exc_info.value)
+
+    full_config = ExperimentBuilder().fetch_full_config(cmdargs)
+    exp = ExperimentBuilder().build_from_config(full_config)
+
+    assert exp._init_done is True
+    assert exp._db is create_db_instance
+    assert exp.name == cmdargs['name']
+    assert exp.refers is None
+    assert exp.metadata['datetime'] == random_dt
+    assert exp.metadata['user'] == 'tsirif'
+    assert exp.metadata['user_args'] == cmdargs['user_args']
+    assert exp._last_fetched == random_dt
+    assert exp.pool_size == 1
+    assert exp.max_trials == 100
+    assert exp.status == 'pending'
+    assert exp.algorithms.configuration == {'random': {}}
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_build_from_config_hit(old_config_file, create_db_instance, exp_config):
+    """Try building experiment from config when in db (no branch)"""
+    cmdargs = {'name': 'supernaedo2',
+               'config': old_config_file,
+               'user_args': ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])",
+                             "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"],
+               'user_script': 'full_path/main.py'}
+
+    # Test that experiment already exists
+    ExperimentBuilder().build_view_from(cmdargs)
+
+    exp_view = ExperimentBuilder().build_view_from(cmdargs)
+    exp = ExperimentBuilder().build_from_config(exp_view.configuration)
+
+    assert exp._init_done is True
+    assert exp._db is create_db_instance
+    assert exp._id == exp_config[0][0]['_id']
+    assert exp.name == exp_config[0][0]['name']
+    assert exp.refers == exp_config[0][0]['refers']
+    assert exp.metadata == exp_config[0][0]['metadata']
+    assert exp._last_fetched == exp_config[0][0]['metadata']['datetime']
+    assert exp.pool_size == exp_config[0][0]['pool_size']
+    assert exp.max_trials == exp_config[0][0]['max_trials']
+    assert exp.status == exp_config[0][0]['status']
+    assert exp.algorithms.configuration == exp_config[0][0]['algorithms']

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -11,7 +11,7 @@ from orion.core.io.experiment_builder import ExperimentBuilder
 def test_fetch_local_config(config_file):
     """Test local config (default, env_vars, cmdconfig, cmdargs)"""
     cmdargs = {"config": config_file}
-    local_config = ExperimentBuilder().fetch_local_config(cmdargs)
+    local_config = ExperimentBuilder().fetch_full_config(cmdargs, use_db=False)
 
     assert local_config['algorithms'] == 'random'
     assert local_config['database']['host'] == 'mongodb://user:pass@localhost'
@@ -30,7 +30,7 @@ def test_fetch_local_config_from_incomplete_config(incomplete_config_file):
     This is to ensure merge_configs update properly the subconfigs
     """
     cmdargs = {"config": incomplete_config_file}
-    local_config = ExperimentBuilder().fetch_local_config(cmdargs)
+    local_config = ExperimentBuilder().fetch_full_config(cmdargs, use_db=False)
 
     assert local_config['algorithms'] == 'random'
     assert local_config['database']['host'] == 'mongodb://user:pass@localhost'

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -3,6 +3,7 @@
 """Example usage and tests for :mod:`orion.core.io.resolve_config`."""
 
 import os
+import socket
 
 import pytest
 
@@ -23,7 +24,7 @@ def test_fetch_default_options():
     default_config = resolve_config.fetch_default_options()
 
     assert default_config['algorithms'] == 'random'
-    assert default_config['database']['host'] == '127.0.1.1'
+    assert default_config['database']['host'] == socket.gethostbyname(socket.gethostname())
     assert default_config['database']['name'] == 'orion'
     assert default_config['database']['type'] == 'MongoDB'
 

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Example usage and tests for :mod:`orion.core.io.resolve_config`."""
+
+
+import os
+
+import orion.core.io.resolve_config as resolve_config
+
+
+def test_fetch_default_options():
+    """Verify default options"""
+    default_config = resolve_config.fetch_default_options()
+
+    assert default_config['algorithms'] == 'random'
+    assert default_config['database']['host'] == '127.0.1.1'
+    assert default_config['database']['name'] == 'orion'
+    assert default_config['database']['type'] == 'MongoDB'
+
+    assert default_config['max_trials'] == float('inf')
+    assert default_config['name'] is None
+    assert default_config['pool_size'] == 10
+
+
+def test_fetch_env_vars():
+    """Verify env vars are fetched properly"""
+    env_vars_config = resolve_config.fetch_env_vars()
+    assert env_vars_config == {'database': {}}
+
+    db_name = "orion_test"
+
+    os.environ['ORION_DB_NAME'] = db_name
+
+    env_vars_config = resolve_config.fetch_env_vars()
+    assert env_vars_config == {'database': {'name': 'orion_test'}}
+
+    db_type = "MongoDB"
+    os.environ['ORION_DB_TYPE'] = db_type
+
+    env_vars_config = resolve_config.fetch_env_vars()
+    assert env_vars_config == {'database': {'name': db_name, 'type': db_type}}
+
+
+def test_fetch_config_no_hit():
+    """Verify fetch_config returns empty dict on no config file path"""
+    config = resolve_config.fetch_config({"config": ""})
+    assert config == {}
+
+
+def test_fetch_config(config_file):
+    """Verify fetch_config returns valid dictionnary"""
+    config = resolve_config.fetch_config({"config": config_file})
+
+    assert config['algorithms'] == 'random'
+    assert config['database']['host'] == 'mongodb://user:pass@localhost'
+    assert config['database']['name'] == 'orion_test'
+    assert config['database']['type'] == 'mongodb'
+
+    assert config['max_trials'] == 100
+    assert config['name'] == 'voila_voici'
+    assert config['pool_size'] == 1
+
+
+def test_merge_configs_update_two():
+    """Ensure update on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'a': 3}
+
+    m = resolve_config.merge_configs(a, b)
+
+    assert m == {'a': 3, 'b': 2}
+
+
+def test_merge_configs_update_three():
+    """Ensure two updates on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'a': 3}
+    c = {'b': 4}
+
+    m = resolve_config.merge_configs(a, b, c)
+
+    assert m == {'a': 3, 'b': 4}
+
+
+def test_merge_configs_update_four():
+    """Ensure three updates on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'a': 3}
+    c = {'b': 4}
+    d = {'a': 5, 'b': 6}
+
+    m = resolve_config.merge_configs(a, b, c, d)
+
+    assert m == {'a': 5, 'b': 6}
+
+
+def test_merge_configs_extend_two():
+    """Ensure extension on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'c': 3}
+
+    m = resolve_config.merge_configs(a, b)
+
+    assert m == {'a': 1, 'b': 2, 'c': 3}
+
+
+def test_merge_configs_extend_three():
+    """Ensure two extensions on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'c': 3}
+    c = {'d': 4}
+
+    m = resolve_config.merge_configs(a, b, c)
+
+    assert m == {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+
+
+def test_merge_configs_extend_four():
+    """Ensure three extensions on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'c': 3}
+    c = {'d': 4}
+    d = {'e': 5}
+
+    m = resolve_config.merge_configs(a, b, c, d)
+
+    assert m == {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5}
+
+
+def test_merge_configs_update_extend_two():
+    """Ensure update and extension on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'b': 3, 'c': 4}
+
+    m = resolve_config.merge_configs(a, b)
+
+    assert m == {'a': 1, 'b': 3, 'c': 4}
+
+
+def test_merge_configs_update_extend_three():
+    """Ensure two updates and extensions on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'b': 3, 'c': 4}
+    c = {'a': 5, 'd': 6}
+
+    m = resolve_config.merge_configs(a, b, c)
+
+    assert m == {'a': 5, 'b': 3, 'c': 4, 'd': 6}
+
+
+def test_merge_configs_update_extend_four():
+    """Ensure three updates and extensions on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'b': 3, 'c': 4}
+    c = {'a': 5, 'd': 6}
+    d = {'d': 7, 'e': 8}
+
+    m = resolve_config.merge_configs(a, b, c, d)
+
+    assert m == {'a': 5, 'b': 3, 'c': 4, 'd': 7, 'e': 8}
+
+
+def test_merge_sub_configs_update_two():
+    """Ensure updating to second level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'b': {'c': 3}}
+
+    m = resolve_config.merge_configs(a, b)
+
+    assert m == {'a': 1, 'b': {'c': 3}}
+
+
+def test_merge_sub_configs_sub_update_two():
+    """Ensure updating on second level is fine"""
+    a = {'a': 1, 'b': {'c': 2}}
+    b = {'b': {'c': 3}}
+
+    m = resolve_config.merge_configs(a, b)
+
+    assert m == {'a': 1, 'b': {'c': 3}}
+
+    a = {'a': 1, 'b': {'c': 2, 'd': 3}}
+    b = {'b': {'c': 4}}
+
+    m = resolve_config.merge_configs(a, b)
+
+    assert m == {'a': 1, 'b': {'c': 4, 'd': 3}}
+
+
+def test_merge_sub_configs_sub_extend_two():
+    """Ensure updating to third level from second level is fine"""
+    a = {'a': 1, 'b': {'c': 2}}
+    b = {'d': {'e': 3}}
+
+    m = resolve_config.merge_configs(a, b)
+
+    assert m == {'a': 1, 'b': {'c': 2}, 'd': {'e': 3}}
+
+    a = {'a': 1, 'b': {'c': 2, 'd': 3}}
+    b = {'b': {'e': {'f': 4}}}
+
+    m = resolve_config.merge_configs(a, b)
+
+    assert m == {'a': 1, 'b': {'c': 2, 'd': 3, 'e': {'f': 4}}}
+
+
+def test_merge_sub_configs_update_three():
+    """Ensure updating twice to third level from second level is fine"""
+    a = {'a': 1, 'b': {'c': 2}}
+    b = {'b': {'c': 3}}
+    c = {'b': {'c': {'d': 4}}}
+
+    m = resolve_config.merge_configs(a, b, c)
+
+    assert m == {'a': 1, 'b': {'c': {'d': 4}}}
+
+    a = {'a': 1, 'b': {'c': 2, 'd': 3}}
+    b = {'b': {'c': 4}}
+    c = {'b': {'c': {'e': 5}}}
+
+    m = resolve_config.merge_configs(a, b, c)
+
+    assert m == {'a': 1, 'b': {'c': {'e': 5}, 'd': 3}}
+
+
+def test_infer_versioning_metadata():
+    """Verify infer_versioning_metadata does nothing so far
+
+    Test should be broken once the function is implemented
+    """
+    metadata = {'hello': {'world': 0}}
+    assert resolve_config.infer_versioning_metadata(metadata) == metadata

--- a/tests/unittests/core/mongodb_test.py
+++ b/tests/unittests/core/mongodb_test.py
@@ -250,13 +250,13 @@ class TestRead(object):
             'trials',
             {'experiment': 'supernaedo2',
              'submit_time': {'$gte': datetime(2017, 11, 23, 0, 0, 0)}})
-        assert value == exp_config[1][2:]
+        assert value == exp_config[1][2:7]
 
         value = orion_db.read(
             'trials',
             {'experiment': 'supernaedo2',
              'submit_time': {'$gt': datetime(2017, 11, 23, 0, 0, 0)}})
-        assert value == exp_config[1][3:]
+        assert value == exp_config[1][3:7]
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -299,7 +299,8 @@ class TestWrite(object):
         value = list(database.experiments.find({}))
         assert value[0]['pool_size'] == 16
         assert value[1]['pool_size'] == 16
-        assert value[2]['pool_size'] == 2
+        assert value[2]['pool_size'] == 16
+        assert value[3]['pool_size'] == 2
 
     def test_update_with_id(self, exp_config, database, orion_db):
         """Query using ``_id`` key."""
@@ -344,8 +345,8 @@ class TestReadAndWrite(object):
             'experiments',
             {'name': 'supernaedo2', 'metadata.user': 'dendi'},
             {'pool_size': 'lalala'})
-        exp_config[0][2]['pool_size'] = 'lalala'
-        assert loaded_config == exp_config[0][2]
+        exp_config[0][3]['pool_size'] = 'lalala'
+        assert loaded_config == exp_config[0][3]
 
     def test_read_and_write_many(self, database, orion_db, exp_config):
         """Should update only one entry."""
@@ -385,11 +386,12 @@ class TestRemove(object):
         """Should match existing entries, and delete them all."""
         filt = {'metadata.user': 'tsirif'}
         count_before = database.experiments.count()
+        count_filt = database.experiments.count(filt)
         # call interface
         assert orion_db.remove('experiments', filt) is True
-        assert database.experiments.count() == count_before - 2
+        assert database.experiments.count() == count_before - count_filt
         assert database.experiments.count() == 1
-        assert list(database.experiments.find()) == [exp_config[0][2]]
+        assert list(database.experiments.find()) == [exp_config[0][3]]
 
     def test_remove_with_id(self, exp_config, database, orion_db):
         """Query using ``_id`` key."""

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -324,13 +324,11 @@ class TestConfigProperty(object):
             exp.configure(new_config)
         assert 'inconsistent' in str(exc_info.value)
 
-    def test_inconsistent_3_set_before_init_no_hit(self, random_dt, new_config):
+    def test_not_inconsistent_3_set_before_init_no_hit(self, random_dt, new_config):
         """Test inconsistent configuration because of datetime."""
         exp = Experiment(new_config['name'])
         new_config['metadata']['datetime'] = 123
-        with pytest.raises(ValueError) as exc_info:
-            exp.configure(new_config)
-        assert 'inconsistent' in str(exc_info.value)
+        exp.configure(new_config)
 
     def test_get_after_init_plus_hit_no_diffs(self, exp_config):
         """Return a configuration dict according to an experiment object.

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -151,9 +151,8 @@ class TestInitExperiment(object):
         assert exp.name == 'supernaekei'
         assert exp.refers is None
         assert exp.metadata['user'] == 'tsirif'
-        assert exp.metadata['datetime'] == random_dt
         assert exp._last_fetched == random_dt
-        assert len(exp.metadata) == 2
+        assert len(exp.metadata) == 1
         assert exp.pool_size is None
         assert exp.max_trials is None
         assert exp.algorithms is None
@@ -170,9 +169,8 @@ class TestInitExperiment(object):
         assert exp.name == 'supernaedo2'
         assert exp.refers is None
         assert exp.metadata['user'] == 'bouthilx'
-        assert exp.metadata['datetime'] == random_dt
         assert exp._last_fetched == random_dt
-        assert len(exp.metadata) == 2
+        assert len(exp.metadata) == 1
         assert exp.pool_size is None
         assert exp.max_trials is None
         assert exp.algorithms is None
@@ -222,8 +220,7 @@ class TestConfigProperty(object):
         assert cfg['name'] == 'supernaekei'
         assert cfg['refers'] is None
         assert cfg['metadata']['user'] == 'tsirif'
-        assert cfg['metadata']['datetime'] == random_dt
-        assert len(cfg['metadata']) == 2
+        assert len(cfg['metadata']) == 1
         assert cfg['pool_size'] is None
         assert cfg['max_trials'] is None
         assert cfg['algorithms'] is None

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -588,23 +588,25 @@ class TestInitExperimentView(object):
 
     @pytest.mark.usefixtures("with_user_tsirif")
     def test_empty_experiment_view(self):
-        """Hit user name, but exp_name does not hit the db, create new entry."""
-        exp = ExperimentView('supernaekei')
-
-        assert exp._id is None
+        """Hit user name, but exp_name does not hit the db."""
+        with pytest.raises(ValueError) as exc_info:
+            ExperimentView('supernaekei')
+        assert ("No experiment with given name 'supernaekei' for user 'tsirif'"
+                in str(exc_info.value))
 
     @pytest.mark.usefixtures("with_user_bouthilx")
     def test_empty_experiment_view_due_to_username(self):
         """Hit exp_name, but user's name does not hit the db, create new entry."""
-        exp = ExperimentView('supernaekei')
-
-        assert exp._id is None
+        with pytest.raises(ValueError) as exc_info:
+            ExperimentView('supernaedo2')
+        assert ("No experiment with given name 'supernaedo2' for user 'bouthilx'"
+                in str(exc_info.value))
 
     @pytest.mark.usefixtures("with_user_tsirif")
     def test_existing_experiment_view(self, create_db_instance, exp_config):
         """Hit exp_name + user's name in the db, fetch most recent entry."""
         exp = ExperimentView('supernaedo2')
-        assert exp._experiment._init_done is False
+        assert exp._experiment._init_done is True
         assert exp._experiment._db._database is create_db_instance
         assert exp._id == exp_config[0][0]['_id']
         assert exp.name == exp_config[0][0]['name']

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -600,7 +600,7 @@ def test_fetch_completed_trials(hacked_exp, exp_config, random_dt):
     """Fetch a list of the unseen yet completed trials."""
     trials = hacked_exp.fetch_completed_trials()
     assert hacked_exp._last_fetched == random_dt
-    assert len(trials) == 3
+    assert len(trials) == 6
     assert trials[0].to_dict() == exp_config[1][0]
     assert trials[1].to_dict() == exp_config[1][1]
     assert trials[2].to_dict() == exp_config[1][2]
@@ -625,7 +625,7 @@ def test_is_done_property_with_algo(hacked_exp):
 def test_experiment_stats(hacked_exp, exp_config, random_dt):
     """Check that property stats is returning a proper summary of experiment's results."""
     stats = hacked_exp.stats
-    assert stats['trials_completed'] == 3
+    assert stats['trials_completed'] == 6
     assert stats['best_trials_id'] == exp_config[1][1]['_id']
     assert stats['best_evaluation'] == 2
     assert stats['start_time'] == exp_config[0][3]['metadata']['datetime']
@@ -690,7 +690,7 @@ def test_fetch_completed_trials_from_view(hacked_exp, exp_config, random_dt):
 
     trials = experiment_view.fetch_completed_trials()
     assert experiment_view._experiment._last_fetched == random_dt
-    assert len(trials) == 3
+    assert len(trials) == 6
     assert trials[0].to_dict() == exp_config[1][0]
     assert trials[1].to_dict() == exp_config[1][1]
     assert trials[2].to_dict() == exp_config[1][2]
@@ -737,7 +737,7 @@ def test_experiment_view_stats(hacked_exp, exp_config, random_dt):
     experiment_view._experiment = hacked_exp
 
     stats = experiment_view.stats
-    assert stats['trials_completed'] == 3
+    assert stats['trials_completed'] == 6
     assert stats['best_trials_id'] == exp_config[1][1]['_id']
     assert stats['best_evaluation'] == 2
     assert stats['start_time'] == exp_config[0][3]['metadata']['datetime']

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -774,11 +774,11 @@ class TestInitExperimentWithEVC(object):
         assert exp._id is not None
         assert exp.name == 'supernaedo2.6'
         assert exp.configuration['refers'] == exp_config[0][4]['refers']
+        exp_config[0][4]['metadata']['datetime'] = random_dt
         assert exp.metadata == exp_config[0][4]['metadata']
         assert exp._last_fetched == random_dt
         assert exp.pool_size is None
         assert exp.max_trials is None
-        assert exp.status == 'pending'
         assert exp.configuration['algorithms'] == {'random': {}}
 
     @pytest.mark.usefixtures("with_user_tsirif")
@@ -795,5 +795,4 @@ class TestInitExperimentWithEVC(object):
         assert exp.metadata == exp_config[0][4]['metadata']
         assert exp.pool_size == 2
         assert exp.max_trials == 1000
-        assert exp.status == 'pending'
         assert exp.configuration['algorithms'] == {'random': {}}

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -665,6 +665,22 @@ def test_view_is_done_property(hacked_exp):
     assert experiment_view.is_done is True
 
 
+def test_view_algo_is_done_property(hacked_exp):
+    """Check experiment's algo stopping conditions accessed from view."""
+    experiment_view = ExperimentView(hacked_exp.name)
+    experiment_view._experiment = hacked_exp
+
+    # Fully configure wrapper experiment (should normally occur inside ExperimentView.__init__
+    # but hacked_exp has been _hacked_ inside afterwards.
+    hacked_exp.configure(hacked_exp.configuration)
+
+    assert experiment_view.is_done is False
+
+    hacked_exp.algorithms.algorithm.done = True
+
+    assert experiment_view.is_done is True
+
+
 def test_experiment_view_stats(hacked_exp, exp_config, random_dt):
     """Check that property stats from view is consistent."""
     experiment_view = ExperimentView(hacked_exp.name)

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -505,7 +505,7 @@ class TestReserveTrial(object):
     def test_reserve_with_score(self, hacked_exp, exp_config):
         """Reserve with a score object that can do its job."""
         self.times_called = 0
-        hacked_exp.configure(exp_config[0][2])
+        hacked_exp.configure(exp_config[0][3])
         trial = hacked_exp.reserve_trial(score_handle=self.fake_handle)
         exp_config[1][6]['status'] = 'reserved'
         assert trial.to_dict() == exp_config[1][6]
@@ -577,7 +577,7 @@ def test_experiment_stats(hacked_exp, exp_config, random_dt):
     assert stats['trials_completed'] == 3
     assert stats['best_trials_id'] == exp_config[1][1]['_id']
     assert stats['best_evaluation'] == 2
-    assert stats['start_time'] == exp_config[0][2]['metadata']['datetime']
+    assert stats['start_time'] == exp_config[0][3]['metadata']['datetime']
     assert stats['finish_time'] == exp_config[1][2]['end_time']
     assert stats['duration'] == stats['finish_time'] - stats['start_time']
     assert len(stats) == 6
@@ -670,7 +670,7 @@ def test_experiment_view_stats(hacked_exp, exp_config, random_dt):
     assert stats['trials_completed'] == 3
     assert stats['best_trials_id'] == exp_config[1][1]['_id']
     assert stats['best_evaluation'] == 2
-    assert stats['start_time'] == exp_config[0][2]['metadata']['datetime']
+    assert stats['start_time'] == exp_config[0][3]['metadata']['datetime']
     assert stats['finish_time'] == exp_config[1][2]['end_time']
     assert stats['duration'] == stats['finish_time'] - stats['start_time']
     assert len(stats) == 6

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -482,6 +482,23 @@ class TestConfigProperty(object):
         assert exp._id == new_config.pop('_id')
         assert exp.configuration == new_config
 
+    @pytest.mark.usefixtures("trial_id_substitution")
+    def test_status_is_pending_when_increase_max_trials(self, exp_config):
+        """Attribute exp.algorithms become objects after init."""
+        exp = Experiment('supernaedo4')
+
+        # Deliver an external configuration to finalize init
+        exp.configure(exp_config[0][2])
+
+        assert exp.is_done
+
+        exp = Experiment('supernaedo4')
+        # Deliver an external configuration to finalize init
+        exp_config[0][2]['max_trials'] = 1000
+        exp.configure(exp_config[0][2])
+
+        assert not exp.is_done
+
 
 class TestReserveTrial(object):
     """Calls to interface `Experiment.reserve_trial`."""
@@ -652,7 +669,6 @@ class TestInitExperimentView(object):
         assert exp._experiment._last_fetched == exp_config[0][0]['metadata']['datetime']
         assert exp.pool_size == exp_config[0][0]['pool_size']
         assert exp.max_trials == exp_config[0][0]['max_trials']
-        assert exp.status == exp_config[0][0]['status']
         assert exp.algorithms.configuration == exp_config[0][0]['algorithms']
 
         with pytest.raises(AttributeError):

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -369,11 +369,11 @@ class TestConfigProperty(object):
         initialized and needs to be rebuilt.
         """
         exp = Experiment(new_config['name'])
-        assert exp.status is None
+        assert exp.id is None
         # Another experiment gets configured first
         experiment_count_before = exp._db.count("experiments")
         naughty_little_exp = Experiment(new_config['name'])
-        assert naughty_little_exp.status is None
+        assert naughty_little_exp.id is None
         naughty_little_exp.configure(new_config)
         assert naughty_little_exp._init_done is True
         assert exp._init_done is False
@@ -395,13 +395,10 @@ class TestConfigProperty(object):
         """
         # Another experiment gets configured first
         naughty_little_exp = Experiment(new_config['name'])
-        assert naughty_little_exp.status is None
+        assert naughty_little_exp.id is None
         experiment_count_before = naughty_little_exp._db.count("experiments")
         naughty_little_exp.configure(copy.deepcopy(new_config))
         assert naughty_little_exp._init_done is True
-
-        import pprint
-        pprint.pprint(new_config)
 
         exp = Experiment(new_config['name'])
         assert exp._init_done is False

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -651,6 +651,10 @@ def test_view_is_done_property(hacked_exp):
     experiment_view = ExperimentView(hacked_exp.name)
     experiment_view._experiment = hacked_exp
 
+    # Fully configure wrapper experiment (should normally occur inside ExperimentView.__init__
+    # but hacked_exp has been _hacked_ inside afterwards.
+    hacked_exp.configure(hacked_exp.configuration)
+
     assert experiment_view.is_done is False
 
     with pytest.raises(AttributeError):

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -616,7 +616,7 @@ class TestInitExperimentView(object):
         assert exp.pool_size == exp_config[0][0]['pool_size']
         assert exp.max_trials == exp_config[0][0]['max_trials']
         assert exp.status == exp_config[0][0]['status']
-        assert exp.algorithms == exp_config[0][0]['algorithms']
+        assert exp.algorithms.configuration == exp_config[0][0]['algorithms']
 
         with pytest.raises(AttributeError):
             exp.this_is_not_in_config = 5

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -756,3 +756,44 @@ def test_experiment_view_db_read_only():
     exp._experiment._db._database.write
     with pytest.raises(AttributeError):
         exp._experiment._db.write
+
+
+class TestInitExperimentWithEVC(object):
+    """Create new Experiment instance with EVC."""
+
+    @pytest.mark.usefixtures("with_user_tsirif")
+    def test_new_experiment_with_parent(self, create_db_instance, random_dt, exp_config):
+        """Configure a branch experiment."""
+        exp = Experiment('supernaedo2.6')
+        exp.metadata = exp_config[0][4]['metadata']
+        exp.refers = exp_config[0][4]['refers']
+        exp.algorithms = exp_config[0][4]['algorithms']
+        exp.configure(exp.configuration)
+        assert exp._init_done is True
+        assert exp._db is create_db_instance
+        assert exp._id is not None
+        assert exp.name == 'supernaedo2.6'
+        assert exp.configuration['refers'] == exp_config[0][4]['refers']
+        assert exp.metadata == exp_config[0][4]['metadata']
+        assert exp._last_fetched == random_dt
+        assert exp.pool_size is None
+        assert exp.max_trials is None
+        assert exp.status == 'pending'
+        assert exp.configuration['algorithms'] == {'random': {}}
+
+    @pytest.mark.usefixtures("with_user_tsirif")
+    def test_experiment_with_parent(self, create_db_instance, random_dt, exp_config):
+        """Configure an existing experiment with parent."""
+        exp = Experiment('supernaedo2.1')
+        exp.algorithms = {'random': {}}
+        exp.configure(exp.configuration)
+        assert exp._init_done is True
+        assert exp._db is create_db_instance
+        assert exp._id is not None
+        assert exp.name == 'supernaedo2.1'
+        assert exp.configuration['refers'] == exp_config[0][4]['refers']
+        assert exp.metadata == exp_config[0][4]['metadata']
+        assert exp.pool_size == 2
+        assert exp.max_trials == 1000
+        assert exp.status == 'pending'
+        assert exp.configuration['algorithms'] == {'random': {}}

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -9,7 +9,7 @@ import pytest
 
 from orion.algo.base import BaseAlgorithm
 from orion.core.io.database import Database, DuplicateKeyError
-from orion.core.worker.experiment import Experiment
+from orion.core.worker.experiment import Experiment, ExperimentView
 from orion.core.worker.trial import Trial
 
 
@@ -581,3 +581,105 @@ def test_experiment_stats(hacked_exp, exp_config, random_dt):
     assert stats['finish_time'] == exp_config[1][2]['end_time']
     assert stats['duration'] == stats['finish_time'] - stats['start_time']
     assert len(stats) == 6
+
+
+class TestInitExperimentView(object):
+    """Create new ExperimentView instance."""
+
+    @pytest.mark.usefixtures("with_user_tsirif")
+    def test_empty_experiment_view(self):
+        """Hit user name, but exp_name does not hit the db, create new entry."""
+        exp = ExperimentView('supernaekei')
+
+        assert exp._id is None
+
+    @pytest.mark.usefixtures("with_user_bouthilx")
+    def test_empty_experiment_view_due_to_username(self):
+        """Hit exp_name, but user's name does not hit the db, create new entry."""
+        exp = ExperimentView('supernaekei')
+
+        assert exp._id is None
+
+    @pytest.mark.usefixtures("with_user_tsirif")
+    def test_existing_experiment_view(self, create_db_instance, exp_config):
+        """Hit exp_name + user's name in the db, fetch most recent entry."""
+        exp = ExperimentView('supernaedo2')
+        assert exp._experiment._init_done is False
+        assert exp._experiment._db._database is create_db_instance
+        assert exp._id == exp_config[0][0]['_id']
+        assert exp.name == exp_config[0][0]['name']
+        assert exp.refers == exp_config[0][0]['refers']
+        assert exp.metadata == exp_config[0][0]['metadata']
+        assert exp._experiment._last_fetched == exp_config[0][0]['metadata']['datetime']
+        assert exp.pool_size == exp_config[0][0]['pool_size']
+        assert exp.max_trials == exp_config[0][0]['max_trials']
+        assert exp.status == exp_config[0][0]['status']
+        assert exp.algorithms == exp_config[0][0]['algorithms']
+
+        with pytest.raises(AttributeError):
+            exp.this_is_not_in_config = 5
+
+        # Test that experiment.push_completed_trial indeed exists
+        exp._experiment.push_completed_trial
+        with pytest.raises(AttributeError):
+            exp.push_completed_trial
+
+        with pytest.raises(AttributeError):
+            exp.register_trials
+
+        with pytest.raises(AttributeError):
+            exp.reserve_trial
+
+
+def test_fetch_completed_trials_from_view(hacked_exp, exp_config, random_dt):
+    """Fetch a list of the unseen yet completed trials."""
+    experiment_view = ExperimentView(hacked_exp.name)
+    experiment_view._experiment = hacked_exp
+
+    trials = experiment_view.fetch_completed_trials()
+    assert experiment_view._experiment._last_fetched == random_dt
+    assert len(trials) == 3
+    assert trials[0].to_dict() == exp_config[1][0]
+    assert trials[1].to_dict() == exp_config[1][1]
+    assert trials[2].to_dict() == exp_config[1][2]
+
+
+def test_view_is_done_property(hacked_exp):
+    """Check experiment stopping conditions accessed from view."""
+    experiment_view = ExperimentView(hacked_exp.name)
+    experiment_view._experiment = hacked_exp
+
+    assert experiment_view.is_done is False
+
+    with pytest.raises(AttributeError):
+        experiment_view.max_trials = 2
+
+    hacked_exp.max_trials = 2
+
+    assert experiment_view.is_done is True
+
+
+def test_experiment_view_stats(hacked_exp, exp_config, random_dt):
+    """Check that property stats from view is consistent."""
+    experiment_view = ExperimentView(hacked_exp.name)
+    experiment_view._experiment = hacked_exp
+
+    stats = experiment_view.stats
+    assert stats['trials_completed'] == 3
+    assert stats['best_trials_id'] == exp_config[1][1]['_id']
+    assert stats['best_evaluation'] == 2
+    assert stats['start_time'] == exp_config[0][2]['metadata']['datetime']
+    assert stats['finish_time'] == exp_config[1][2]['end_time']
+    assert stats['duration'] == stats['finish_time'] - stats['start_time']
+    assert len(stats) == 6
+
+
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_experiment_view_db_read_only():
+    """Verify that wrapper experiments' database is read-only"""
+    exp = ExperimentView('supernaedo2')
+
+    # Test that database.write indeed exists
+    exp._experiment._db._database.write
+    with pytest.raises(AttributeError):
+        exp._experiment._db.write

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -148,7 +148,7 @@ class TestInitExperiment(object):
         assert exp._db is create_db_instance
         assert exp._id is None
         assert exp.name == 'supernaekei'
-        assert exp.refers is None
+        assert exp.refers == {}
         assert exp.metadata['user'] == 'tsirif'
         assert exp._last_fetched == random_dt
         assert len(exp.metadata) == 1
@@ -166,7 +166,7 @@ class TestInitExperiment(object):
         assert exp._db is create_db_instance
         assert exp._id is None
         assert exp.name == 'supernaedo2'
-        assert exp.refers is None
+        assert exp.refers == {}
         assert exp.metadata['user'] == 'bouthilx'
         assert exp._last_fetched == random_dt
         assert len(exp.metadata) == 1
@@ -217,7 +217,7 @@ class TestConfigProperty(object):
         exp = Experiment('supernaekei')
         cfg = exp.configuration
         assert cfg['name'] == 'supernaekei'
-        assert cfg['refers'] is None
+        assert cfg['refers'] == {}
         assert cfg['metadata']['user'] == 'tsirif'
         assert len(cfg['metadata']) == 1
         assert cfg['pool_size'] is None
@@ -291,7 +291,7 @@ class TestConfigProperty(object):
         _id = found_config[0].pop('_id')
         assert _id != 'fasdfasfa'
         assert exp._id == _id
-        new_config['refers'] = None
+        new_config['refers'] = {}
         new_config.pop('_id')
         new_config.pop('something_to_be_ignored')
         new_config['algorithms']['dumbalgo']['done'] = False
@@ -299,9 +299,10 @@ class TestConfigProperty(object):
         new_config['algorithms']['dumbalgo']['scoring'] = 0
         new_config['algorithms']['dumbalgo']['suspend'] = False
         new_config['algorithms']['dumbalgo']['value'] = 5
+        new_config['refers'] = {'adapter': [], 'parent_id': None, 'root_id': _id}
         assert found_config[0] == new_config
         assert exp.name == new_config['name']
-        assert exp.refers is None
+        assert exp.configuration['refers'] == new_config['refers']
         assert exp.metadata == new_config['metadata']
         assert exp.pool_size == new_config['pool_size']
         assert exp.max_trials == new_config['max_trials']
@@ -661,7 +662,7 @@ class TestInitExperimentView(object):
         assert exp._experiment._db._database is create_db_instance
         assert exp._id == exp_config[0][0]['_id']
         assert exp.name == exp_config[0][0]['name']
-        assert exp.refers == exp_config[0][0]['refers']
+        assert exp.configuration['refers'] == exp_config[0][0]['refers']
         assert exp.metadata == exp_config[0][0]['metadata']
         assert exp._experiment._last_fetched == exp_config[0][0]['metadata']['datetime']
         assert exp.pool_size == exp_config[0][0]['pool_size']

--- a/tests/unittests/core/test_producer.py
+++ b/tests/unittests/core/test_producer.py
@@ -10,7 +10,7 @@ from orion.core.worker.producer import Producer
 def producer(hacked_exp, random_dt, exp_config):
     """Return a setup `Producer`."""
     # make init done
-    hacked_exp.configure(exp_config[0][2])
+    hacked_exp.configure(exp_config[0][3])
     # insert fake point
     fake_point = ('lstm', 'gru')
     assert fake_point in hacked_exp.space

--- a/tests/unittests/core/test_producer.py
+++ b/tests/unittests/core/test_producer.py
@@ -24,11 +24,11 @@ def test_update(producer):
     # Algorithm must have received completed points and their results
     obs_points = producer.algorithm.algorithm._points
     obs_results = producer.algorithm.algorithm._results
-    assert len(obs_points) == 3
+    assert len(obs_points) == 6
     assert obs_points[0] == ('rnn', 'rnn')
     assert obs_points[1] == ('rnn', 'rnn')
     assert obs_points[2] == ('gru', 'lstm_with_attention')
-    assert len(obs_results) == 3
+    assert len(obs_results) == 6
     assert obs_results[0] == {
         'objective': 3,
         'gradient': None,

--- a/tests/unittests/core/test_space_builder.py
+++ b/tests/unittests/core/test_space_builder.py
@@ -97,7 +97,7 @@ class TestDimensionBuilder(object):
     def test_build_fails_because_of_ValueError_on_run(self, dimbuilder):
         """Build fails because ValueError happens on init."""
         with pytest.raises(TypeError) as exc:
-            dimbuilder.build('yolo2', 'alpha(0.9, low=4, high=6, shape=2)')
+            dimbuilder.build('yolo2', 'alpha(0.9, low=5, high=6, shape=2)')
         assert 'Parameter' in str(exc.value)
         assert 'Improbable bounds' in str(exc.value.__cause__)
 

--- a/tests/unittests/core/test_trial.py
+++ b/tests/unittests/core/test_trial.py
@@ -53,6 +53,16 @@ class TestTrial(object):
         with pytest.raises(AttributeError):
             Trial.Value(ispii='iela')
 
+    def test_param_bad_init(self):
+        """Other than `Trial.Param.__slots__` are not allowed in __init__ too."""
+        with pytest.raises(AttributeError):
+            Trial.Param(ispii='iela')
+
+    def test_result_bad_init(self):
+        """Other than `Trial.Result.__slots__` are not allowed in __init__ too."""
+        with pytest.raises(AttributeError):
+            Trial.Result(ispii='iela')
+
     def test_not_allowed_status(self):
         """Other than `Trial.allowed_stati` are not allowed in `Trial.status`."""
         t = Trial()

--- a/tests/unittests/core/test_trial.py
+++ b/tests/unittests/core/test_trial.py
@@ -100,6 +100,14 @@ class TestTrial(object):
         trials = Trial.build(exp_config[1])
         assert list(map(lambda x: x.to_dict(), trials)) == exp_config[1]
 
+    @pytest.mark.usefixtures("clean_db")
+    def test_value_equal(self, exp_config):
+        """Compare Param objects using __eq__"""
+        trials = Trial.build(exp_config[1])
+
+        assert trials[0].params[0] == Trial.Param(**exp_config[1][0]['params'][0])
+        assert trials[0].params[1] != Trial.Param(**exp_config[1][0]['params'][0])
+
     def test_str_trial(self, exp_config):
         """Test representation of `Trial`."""
         t = Trial(**exp_config[1][2])


### PR DESCRIPTION
Depends on #84 #91 #92 

Note:

I'm not confident about the EVCBuilder. I consider refactoring the lazy-initialisation of `ExperimentNode` such that `Experiment` can automatically build and instantiate the EVC tree when trying to access it. I wanted to build the tree externally to simplify the process of trimming (when user specify subroot and subleafs), which is not trivial. However I believe the same helper functions used to trim could be used inside the node methods, so that trimming occurs dynamically rather than at build time.

As I said, I'm not sure yet. I'd be happy to discuss it. Obviously there is no time for that because the deadline, so I propose we merge it in current state (all other objections aside) and make such refactoring  next week.

###

## Add EVCBuilder

Why:

Building the EVC tree can by tricky if we support trimming for
optimization on smaller EVC subtree. For example user can define a root
and some leafs that should be the extremums of the tree. Those can be
different than the actual root and leafs of the global EVC tree, making
the trimmed version a small subset of the global version.

How:

Wraps ExperimentBuilder fonctionalities to parse command line.

The process of building the tree is the following:

1. Fetch all documents with a given root_id (root of global tree)
2. Build the global tree based on those shallow documents
   (only minimal info fetched from db)
3. Trim the tree based on root name and leaf names specified by user
4. Turn the shallow nodes into experiment nodes (lazy initialization)

The experiment is then connected to the EVC tree, before being returned.

## Add EVC node to `Experiment`

Why:

For modularity, an `Experiment` does not need to be part of EVC and can
be standalone.

How:

EVC trees can be built using _shallow_ definitions (only pointing to
name of experiments). Once the `item` of the shallow nodes are accessed,
and experiment view is created and is connected to the EVC node. Once
the connection is made, the experiment now have access to trials from
the entire tree. Those trials can be fetched using method
`Experiment.fetch_trials_tree`, a recursive version of
`Experiment.fetch_trials`. Note that both return a list of trials, not a
tree of trials.

Note:

Experiment status and statistics are computed only based on its own
trials, not those of the tree.

##  Update `Experiment` based on new refers definition

Why:

The definition of `refers` is now:

 - `root_id`: Experiment id of the root experiment of the EVC tree
    This helps improve efficiency on db fetches since we can fetch a
    tree simply by specifying the root_id. It is also simple to keep
    coherent compared to a double-linked tree with (parent, children)
    links.
 - `parent_id`: Parent id of the current experiment
 - `adapter`: CompositeAdaptor definition to make trials from parent
    compatible with the current one and vice-versa.

How:

On creation of new experiments, `refers` is updated after the experiment
is added to database such that `refers[root_id]` can point to itself.

Note:

Because `refers` contain sub-dictionaries which are edited after
configuration (adapters instantiation), we need to use deep copies of
the configuration when configuring.

## Add experiment node mechanisms

Why:

The tree of experiments have common use cases like fetching trials and
lazy experiment instantiation. Defining a child `ExperimentNode` is
convenient to group such operations.

How:

ExperimentNode carries an experiment in `item`. If node is created using
only the experiment's name, it will instantiate the experiment only upon
access to `item`. `ExperimentNode.fetch_trials` returns a list of trials
fetched recursively in the EVC tree.

Helper functions to apply operations on the tree, not the node
specifically, are kept outside `ExperimentNode`. Results of helper
functions on the EVC are returned in the form of a tree to keep the
original structure (can be useful when analysing an EVC tree by keeping
experiment results separated in each node).