### PR TITLE
Add ExperimentView and ReadOnlyDB wrapper

### DIFF
--- a/src/orion/core/io/database/__init__.py
+++ b/src/orion/core/io/database/__init__.py
@@ -209,6 +209,36 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
         pass
 
 
+# pylint: disable=too-few-public-methods
+class ReadOnlyDB(object):
+    """Read-only view on a database.
+
+    .. seealso::
+
+        :py:class:`orion.core.io.database.AbstractDB`
+    """
+
+    __slots__ = ('_database', )
+
+    #                     Attributes
+    valid_attributes = (["host", "name", "port", "username", "password"] +
+                        # Properties
+                        ["is_connected"] +
+                        # Methods
+                        ["initiate_connection", "close_connection", "read", "count"])
+
+    def __init__(self, database):
+        """Init method, see attributes of :class:`AbstractDB`."""
+        self._database = database
+
+    def __getattr__(self, attr):
+        """Get attribute only if valid"""
+        if attr not in self.valid_attributes:
+            raise AttributeError("Cannot access attribute %s on view-only experiments." % attr)
+
+        return getattr(self._database, attr)
+
+
 class DatabaseError(RuntimeError):
     """Exception type used to delegate responsibility from any database
     implementation's own Exception types.

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -488,13 +488,12 @@ class ExperimentView(object):
     def __init__(self, name):
         """Initialize viewed experiment object with primary key (:attr:`name`, :attr:`user`).
 
-        Try to find an entry in `Database` with such a key and config this object
-        from it import, if successful. Else, init with default/empty values and
-        insert new entry with this object's attributes in database.
+        Build an experiment from configuration found in `Database` with a key (name, user).
 
         .. note::
 
             A view is fully configured at initialiation. It cannot be reconfigured.
+            If no experiment is found for the key (name, user), a `ValueError` will be raised.
 
         :param name: Describe a configuration with a unique identifier per :attr:`user`.
         :type name: str

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -531,4 +531,4 @@ class ExperimentView(object):
             )
         num_completed_trials = self._experiment._db.count('trials', query)
 
-        return num_completed_trials >= self.max_trials
+        return num_completed_trials >= self.max_trials or self.algorithms.is_done

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -479,9 +479,9 @@ class ExperimentView(object):
     __slots__ = ('_experiment', )
 
     #                     Attributes
-    valid_attributes = (["_id", "name", "refers", "metadata", "pool_size", "max_trials", "status"] +
+    valid_attributes = (["_id", "name", "refers", "metadata", "pool_size", "max_trials"] +
                         # Properties
-                        ["space", "algorithms", "stats", "configuration"] +
+                        ["id", "is_done", "space", "algorithms", "stats", "configuration"] +
                         # Methods
                         ["fetch_completed_trials"])
 
@@ -500,7 +500,7 @@ class ExperimentView(object):
         """
         self._experiment = Experiment(name)
 
-        if self._experiment.status is None:
+        if self._experiment.id is None:
             raise ValueError("No experiment with given name '%s' for user '%s' inside database, "
                              "no view can be created." %
                              (self._experiment.name, self._experiment.metadata['user']))
@@ -514,21 +514,3 @@ class ExperimentView(object):
             raise AttributeError("Cannot access attribute %s on view-only experiments." % name)
 
         return getattr(self._experiment, name)
-
-    @property
-    def is_done(self):
-        """Return True, if this experiment is considered to be finished.
-
-        Note that call to this property will **not** change the status of the experiment in the
-        database. Only writable :class:`orion.core.worker.experiment.Experiment` would do so.
-
-        .. seealso::
-            :attr:`orion.core.worker.experiment.Experiment.is_done`
-        """
-        query = dict(
-            experiment=self._id,
-            status='completed'
-            )
-        num_completed_trials = self._experiment._db.count('trials', query)
-
-        return num_completed_trials >= self.max_trials or self.algorithms.is_done

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -494,13 +494,19 @@ class ExperimentView(object):
 
         .. note::
 
-            A view is **note** initializable. It is meant to access trials and statistics from the
-            experiment..
+            A view is fully configured at initialiation. It cannot be reconfigured.
 
         :param name: Describe a configuration with a unique identifier per :attr:`user`.
         :type name: str
         """
         self._experiment = Experiment(name)
+
+        if self._experiment.status is None:
+            raise ValueError("No experiment with given name '%s' for user '%s' inside database, "
+                             "no view can be created." %
+                             (self._experiment.name, self._experiment.metadata['user']))
+
+        self._experiment.configure(self._experiment.configuration)
         self._experiment._db = ReadOnlyDB(self._experiment._db)
 
     def __getattr__(self, name):

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -15,7 +15,7 @@ import getpass
 import logging
 import random
 
-from orion.core.io.database import (Database, DuplicateKeyError)
+from orion.core.io.database import Database, DuplicateKeyError, ReadOnlyDB
 from orion.core.io.space_builder import SpaceBuilder
 from orion.core.utils.format_trials import trial_to_tuple
 from orion.core.worker.primary_algo import PrimaryAlgo
@@ -464,3 +464,66 @@ class Experiment(object):
                 break
 
         return is_diff
+
+
+# pylint: disable=too-few-public-methods
+class ExperimentView(object):
+    """Non-writable view of an experiment
+
+    .. seealso::
+
+        :py:class:`orion.core.worker.experiment.Experiment` for writable experiments.
+
+    """
+
+    __slots__ = ('_experiment', )
+
+    #                     Attributes
+    valid_attributes = (["_id", "name", "refers", "metadata", "pool_size", "max_trials", "status"] +
+                        # Properties
+                        ["space", "algorithms", "stats"] +
+                        # Methods
+                        ["fetch_completed_trials"])
+
+    def __init__(self, name):
+        """Initialize viewed experiment object with primary key (:attr:`name`, :attr:`user`).
+
+        Try to find an entry in `Database` with such a key and config this object
+        from it import, if successful. Else, init with default/empty values and
+        insert new entry with this object's attributes in database.
+
+        .. note::
+
+            A view is **note** initializable. It is meant to access trials and statistics from the
+            experiment..
+
+        :param name: Describe a configuration with a unique identifier per :attr:`user`.
+        :type name: str
+        """
+        self._experiment = Experiment(name)
+        self._experiment._db = ReadOnlyDB(self._experiment._db)
+
+    def __getattr__(self, name):
+        """Get attribute only if valid"""
+        if name not in self.valid_attributes:
+            raise AttributeError("Cannot access attribute %s on view-only experiments." % name)
+
+        return getattr(self._experiment, name)
+
+    @property
+    def is_done(self):
+        """Return True, if this experiment is considered to be finished.
+
+        Note that call to this property will **not** change the status of the experiment in the
+        database. Only writable :class:`orion.core.worker.experiment.Experiment` would do so.
+
+        .. seealso::
+            :attr:`orion.core.worker.experiment.Experiment.is_done`
+        """
+        query = dict(
+            experiment=self._id,
+            status='completed'
+            )
+        num_completed_trials = self._experiment._db.count('trials', query)
+
+        return num_completed_trials >= self.max_trials

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -481,7 +481,7 @@ class ExperimentView(object):
     #                     Attributes
     valid_attributes = (["_id", "name", "refers", "metadata", "pool_size", "max_trials", "status"] +
                         # Properties
-                        ["space", "algorithms", "stats"] +
+                        ["space", "algorithms", "stats", "configuration"] +
                         # Methods
                         ["fetch_completed_trials"])
 

--- a/tests/unittests/core/conftest.py
+++ b/tests/unittests/core/conftest.py
@@ -114,3 +114,23 @@ def hacked_exp(with_user_dendi, random_dt, clean_db):
     exp = Experiment('supernaedo2')
     exp._id = 'supernaedo2'  # white box hack
     return exp
+
+
+@pytest.fixture()
+def trial_id_substitution(with_user_tsirif, random_dt, clean_db):
+    """Replace trial ids by the actual ids of the experiments."""
+    try:
+        Database(of_type='MongoDB', name='orion_test',
+                 username='user', password='pass')
+    except (TypeError, ValueError):
+        pass
+
+    db = Database()
+    experiments = db.read('experiments', {'metadata.user': 'tsirif'})
+    experiment_dict = dict((experiment['name'], experiment) for experiment in experiments)
+    trials = db.read('trials')
+
+    for trial in trials:
+        query = {'experiment': trial['experiment']}
+        update = {'experiment': experiment_dict[trial['experiment']]['_id']}
+        db.write('trials', update, query)

--- a/tests/unittests/core/database_test.py
+++ b/tests/unittests/core/database_test.py
@@ -52,11 +52,9 @@ class TestDatabaseFactory(object):
 class TestReadOnlyDatabase(object):
     """Test coherence of read-only database and its wrapped database."""
 
-    def test_valid_attributes(self):
+    def test_valid_attributes(self, create_db_instance):
         """Test attributes are coherent from view and wrapped database."""
-        database = Database(of_type='MongoDB', name='orion_test',
-                            username='user', password='pass')
-
+        database = create_db_instance
         readonly_database = ReadOnlyDB(database)
 
         assert readonly_database.is_connected == database.is_connected
@@ -65,11 +63,9 @@ class TestReadOnlyDatabase(object):
         assert readonly_database.username == database.username
         assert readonly_database.password == database.password
 
-    def test_read(self):
+    def test_read(self, create_db_instance):
         """Test read is coherent from view and wrapped database."""
-        database = Database(of_type='MongoDB', name='orion_test',
-                            username='user', password='pass')
-
+        database = create_db_instance
         readonly_database = ReadOnlyDB(database)
 
         args = {"collection_name": "trials", "query": {"experiment": "supernaedo2"}}
@@ -79,11 +75,9 @@ class TestReadOnlyDatabase(object):
         assert len(result) > 0  # Otherwise the test is pointless
         assert readonly_result == result
 
-    def test_invalid_attributes(self):
+    def test_invalid_attributes(self, create_db_instance):
         """Test that attributes for writing are not accessible."""
-        database = Database(of_type='MongoDB', name='orion_test',
-                            username='user', password='pass')
-
+        database = create_db_instance
         readonly_database = ReadOnlyDB(database)
 
         # Test that database.ensure_index indeed exists

--- a/tests/unittests/core/experiment.yaml
+++ b/tests/unittests/core/experiment.yaml
@@ -76,6 +76,35 @@
       suspend: False
       done: False
 
+- name: supernaedo4
+
+  metadata:
+    user: tsirif
+    datetime: 2017-11-22T21:00:00
+    orion_version: 0.1
+    user_script: full_path/ieeeela.py
+    user_args: ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])", "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"]
+    user_vcs: git
+    user_version: ~
+    user_commit_hash: as5f7asf5asfa7sf
+  refers:
+    name: supernaedo1
+    user: tsirif
+    params:
+      - name: decoding_layer
+        type: categorical
+        value: gru
+  pool_size: 2
+  max_trials: 1
+  status: done
+  algorithms:
+    dumbalgo:  # this must be logged as `Experiment` would log it, complete specification
+      value: 5
+      scoring: 0
+      judgement: ~
+      suspend: False
+      done: False
+
 - name: supernaedo2
 
   metadata:
@@ -241,6 +270,28 @@
     - name: /decoding_layer
       type: categorical
       value: gru
+
+- experiment: supernaedo4
+
+  status: completed
+  worker: 1251231
+  submit_time: 2017-11-22T23:00:00
+  start_time: ~
+  end_time: 2017-11-22T22:30:00
+  results:
+    - name: ~
+      type: objective  # objective, constraint
+      value: 2
+    - name: naedw_grad
+      type: gradient
+      value: [-0.1, 2]
+  params:
+    - name: /encoding_layer
+      type: categorical
+      value: rnn
+    - name: /decoding_layer
+      type: categorical
+      value: rnn
 ---
 
 # Example of entries in `workers` collection

--- a/tests/unittests/core/mongodb_test.py
+++ b/tests/unittests/core/mongodb_test.py
@@ -250,13 +250,13 @@ class TestRead(object):
             'trials',
             {'experiment': 'supernaedo2',
              'submit_time': {'$gte': datetime(2017, 11, 23, 0, 0, 0)}})
-        assert value == exp_config[1][2:]
+        assert value == exp_config[1][2:7]
 
         value = orion_db.read(
             'trials',
             {'experiment': 'supernaedo2',
              'submit_time': {'$gt': datetime(2017, 11, 23, 0, 0, 0)}})
-        assert value == exp_config[1][3:]
+        assert value == exp_config[1][3:7]
 
 
 @pytest.mark.usefixtures("clean_db")
@@ -299,7 +299,8 @@ class TestWrite(object):
         value = list(database.experiments.find({}))
         assert value[0]['pool_size'] == 16
         assert value[1]['pool_size'] == 16
-        assert value[2]['pool_size'] == 2
+        assert value[2]['pool_size'] == 16
+        assert value[3]['pool_size'] == 2
 
     def test_update_with_id(self, exp_config, database, orion_db):
         """Query using ``_id`` key."""
@@ -344,8 +345,8 @@ class TestReadAndWrite(object):
             'experiments',
             {'name': 'supernaedo2', 'metadata.user': 'dendi'},
             {'pool_size': 'lalala'})
-        exp_config[0][2]['pool_size'] = 'lalala'
-        assert loaded_config == exp_config[0][2]
+        exp_config[0][3]['pool_size'] = 'lalala'
+        assert loaded_config == exp_config[0][3]
 
     def test_read_and_write_many(self, database, orion_db, exp_config):
         """Should update only one entry."""
@@ -385,11 +386,12 @@ class TestRemove(object):
         """Should match existing entries, and delete them all."""
         filt = {'metadata.user': 'tsirif'}
         count_before = database.experiments.count()
+        count_filt = database.experiments.count(filt)
         # call interface
         assert orion_db.remove('experiments', filt) is True
-        assert database.experiments.count() == count_before - 2
+        assert database.experiments.count() == count_before - count_filt
         assert database.experiments.count() == 1
-        assert list(database.experiments.find()) == [exp_config[0][2]]
+        assert list(database.experiments.find()) == [exp_config[0][3]]
 
     def test_remove_with_id(self, exp_config, database, orion_db):
         """Query using ``_id`` key."""

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -588,23 +588,25 @@ class TestInitExperimentView(object):
 
     @pytest.mark.usefixtures("with_user_tsirif")
     def test_empty_experiment_view(self):
-        """Hit user name, but exp_name does not hit the db, create new entry."""
-        exp = ExperimentView('supernaekei')
-
-        assert exp._id is None
+        """Hit user name, but exp_name does not hit the db."""
+        with pytest.raises(ValueError) as exc_info:
+            ExperimentView('supernaekei')
+        assert ("No experiment with given name 'supernaekei' for user 'tsirif'"
+                in str(exc_info.value))
 
     @pytest.mark.usefixtures("with_user_bouthilx")
     def test_empty_experiment_view_due_to_username(self):
         """Hit exp_name, but user's name does not hit the db, create new entry."""
-        exp = ExperimentView('supernaekei')
-
-        assert exp._id is None
+        with pytest.raises(ValueError) as exc_info:
+            ExperimentView('supernaedo2')
+        assert ("No experiment with given name 'supernaedo2' for user 'bouthilx'"
+                in str(exc_info.value))
 
     @pytest.mark.usefixtures("with_user_tsirif")
     def test_existing_experiment_view(self, create_db_instance, exp_config):
         """Hit exp_name + user's name in the db, fetch most recent entry."""
         exp = ExperimentView('supernaedo2')
-        assert exp._experiment._init_done is False
+        assert exp._experiment._init_done is True
         assert exp._experiment._db._database is create_db_instance
         assert exp._id == exp_config[0][0]['_id']
         assert exp.name == exp_config[0][0]['name']

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -698,6 +698,22 @@ def test_view_is_done_property(hacked_exp):
     assert experiment_view.is_done is True
 
 
+def test_view_algo_is_done_property(hacked_exp):
+    """Check experiment's algo stopping conditions accessed from view."""
+    experiment_view = ExperimentView(hacked_exp.name)
+    experiment_view._experiment = hacked_exp
+
+    # Fully configure wrapper experiment (should normally occur inside ExperimentView.__init__
+    # but hacked_exp has been _hacked_ inside afterwards.
+    hacked_exp.configure(hacked_exp.configuration)
+
+    assert experiment_view.is_done is False
+
+    hacked_exp.algorithms.algorithm.done = True
+
+    assert experiment_view.is_done is True
+
+
 def test_experiment_view_stats(hacked_exp, exp_config, random_dt):
     """Check that property stats from view is consistent."""
     experiment_view = ExperimentView(hacked_exp.name)

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -445,6 +445,39 @@ class TestConfigProperty(object):
         assert exp._id == new_config.pop('_id')
         assert exp.configuration == new_config
 
+    @pytest.mark.usefixtures("trial_id_substitution")
+    def test_status_is_pending_when_increase_max_trials(self, exp_config):
+        """Attribute exp.algorithms become objects after init."""
+        exp = Experiment('supernaedo4')
+
+        # Deliver an external configuration to finalize init
+        exp.configure(exp_config[0][2])
+
+        assert exp.status == "done"
+
+        exp = Experiment('supernaedo4')
+        # Deliver an external configuration to finalize init
+        exp_config[0][2]['max_trials'] = 1000
+        exp.configure(exp_config[0][2])
+
+        assert exp.status == "pending"
+
+    @pytest.mark.usefixtures("trial_id_substitution")
+    def test_status_stays_broken(self, exp_config):
+        """Attribute exp.algorithms become objects after init."""
+        exp = Experiment('supernaedo3')
+        # Deliver an external configuration to finalize init
+        exp.configure(exp_config[0][1])
+
+        assert exp.status == "broken"
+
+        exp = Experiment('supernaedo3')
+        # Deliver an external configuration to finalize init
+        exp_config[0][1]['max_trials'] = 1000
+        exp.configure(exp_config[0][1])
+
+        assert exp.status == "broken"
+
 
 class TestReserveTrial(object):
     """Calls to interface `Experiment.reserve_trial`."""
@@ -505,7 +538,7 @@ class TestReserveTrial(object):
     def test_reserve_with_score(self, hacked_exp, exp_config):
         """Reserve with a score object that can do its job."""
         self.times_called = 0
-        hacked_exp.configure(exp_config[0][2])
+        hacked_exp.configure(exp_config[0][3])
         trial = hacked_exp.reserve_trial(score_handle=self.fake_handle)
         exp_config[1][6]['status'] = 'reserved'
         assert trial.to_dict() == exp_config[1][6]
@@ -577,7 +610,7 @@ def test_experiment_stats(hacked_exp, exp_config, random_dt):
     assert stats['trials_completed'] == 3
     assert stats['best_trials_id'] == exp_config[1][1]['_id']
     assert stats['best_evaluation'] == 2
-    assert stats['start_time'] == exp_config[0][2]['metadata']['datetime']
+    assert stats['start_time'] == exp_config[0][3]['metadata']['datetime']
     assert stats['finish_time'] == exp_config[1][2]['end_time']
     assert stats['duration'] == stats['finish_time'] - stats['start_time']
     assert len(stats) == 6
@@ -651,6 +684,10 @@ def test_view_is_done_property(hacked_exp):
     experiment_view = ExperimentView(hacked_exp.name)
     experiment_view._experiment = hacked_exp
 
+    # Fully configure wrapper experiment (should normally occur inside ExperimentView.__init__
+    # but hacked_exp has been _hacked_ inside afterwards.
+    hacked_exp.configure(hacked_exp.configuration)
+
     assert experiment_view.is_done is False
 
     with pytest.raises(AttributeError):
@@ -670,7 +707,7 @@ def test_experiment_view_stats(hacked_exp, exp_config, random_dt):
     assert stats['trials_completed'] == 3
     assert stats['best_trials_id'] == exp_config[1][1]['_id']
     assert stats['best_evaluation'] == 2
-    assert stats['start_time'] == exp_config[0][2]['metadata']['datetime']
+    assert stats['start_time'] == exp_config[0][3]['metadata']['datetime']
     assert stats['finish_time'] == exp_config[1][2]['end_time']
     assert stats['duration'] == stats['finish_time'] - stats['start_time']
     assert len(stats) == 6

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -453,30 +453,14 @@ class TestConfigProperty(object):
         # Deliver an external configuration to finalize init
         exp.configure(exp_config[0][2])
 
-        assert exp.status == "done"
+        assert exp.is_done
 
         exp = Experiment('supernaedo4')
         # Deliver an external configuration to finalize init
         exp_config[0][2]['max_trials'] = 1000
         exp.configure(exp_config[0][2])
 
-        assert exp.status == "pending"
-
-    @pytest.mark.usefixtures("trial_id_substitution")
-    def test_status_stays_broken(self, exp_config):
-        """Attribute exp.algorithms become objects after init."""
-        exp = Experiment('supernaedo3')
-        # Deliver an external configuration to finalize init
-        exp.configure(exp_config[0][1])
-
-        assert exp.status == "broken"
-
-        exp = Experiment('supernaedo3')
-        # Deliver an external configuration to finalize init
-        exp_config[0][1]['max_trials'] = 1000
-        exp.configure(exp_config[0][1])
-
-        assert exp.status == "broken"
+        assert not exp.is_done
 
 
 class TestReserveTrial(object):
@@ -648,7 +632,6 @@ class TestInitExperimentView(object):
         assert exp._experiment._last_fetched == exp_config[0][0]['metadata']['datetime']
         assert exp.pool_size == exp_config[0][0]['pool_size']
         assert exp.max_trials == exp_config[0][0]['max_trials']
-        assert exp.status == exp_config[0][0]['status']
         assert exp.algorithms.configuration == exp_config[0][0]['algorithms']
 
         with pytest.raises(AttributeError):

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -616,7 +616,7 @@ class TestInitExperimentView(object):
         assert exp.pool_size == exp_config[0][0]['pool_size']
         assert exp.max_trials == exp_config[0][0]['max_trials']
         assert exp.status == exp_config[0][0]['status']
-        assert exp.algorithms == exp_config[0][0]['algorithms']
+        assert exp.algorithms.configuration == exp_config[0][0]['algorithms']
 
         with pytest.raises(AttributeError):
             exp.this_is_not_in_config = 5

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -9,7 +9,7 @@ import pytest
 
 from orion.algo.base import BaseAlgorithm
 from orion.core.io.database import Database, DuplicateKeyError
-from orion.core.worker.experiment import Experiment
+from orion.core.worker.experiment import Experiment, ExperimentView
 from orion.core.worker.trial import Trial
 
 
@@ -581,3 +581,105 @@ def test_experiment_stats(hacked_exp, exp_config, random_dt):
     assert stats['finish_time'] == exp_config[1][2]['end_time']
     assert stats['duration'] == stats['finish_time'] - stats['start_time']
     assert len(stats) == 6
+
+
+class TestInitExperimentView(object):
+    """Create new ExperimentView instance."""
+
+    @pytest.mark.usefixtures("with_user_tsirif")
+    def test_empty_experiment_view(self):
+        """Hit user name, but exp_name does not hit the db, create new entry."""
+        exp = ExperimentView('supernaekei')
+
+        assert exp._id is None
+
+    @pytest.mark.usefixtures("with_user_bouthilx")
+    def test_empty_experiment_view_due_to_username(self):
+        """Hit exp_name, but user's name does not hit the db, create new entry."""
+        exp = ExperimentView('supernaekei')
+
+        assert exp._id is None
+
+    @pytest.mark.usefixtures("with_user_tsirif")
+    def test_existing_experiment_view(self, create_db_instance, exp_config):
+        """Hit exp_name + user's name in the db, fetch most recent entry."""
+        exp = ExperimentView('supernaedo2')
+        assert exp._experiment._init_done is False
+        assert exp._experiment._db._database is create_db_instance
+        assert exp._id == exp_config[0][0]['_id']
+        assert exp.name == exp_config[0][0]['name']
+        assert exp.refers == exp_config[0][0]['refers']
+        assert exp.metadata == exp_config[0][0]['metadata']
+        assert exp._experiment._last_fetched == exp_config[0][0]['metadata']['datetime']
+        assert exp.pool_size == exp_config[0][0]['pool_size']
+        assert exp.max_trials == exp_config[0][0]['max_trials']
+        assert exp.status == exp_config[0][0]['status']
+        assert exp.algorithms == exp_config[0][0]['algorithms']
+
+        with pytest.raises(AttributeError):
+            exp.this_is_not_in_config = 5
+
+        # Test that experiment.push_completed_trial indeed exists
+        exp._experiment.push_completed_trial
+        with pytest.raises(AttributeError):
+            exp.push_completed_trial
+
+        with pytest.raises(AttributeError):
+            exp.register_trials
+
+        with pytest.raises(AttributeError):
+            exp.reserve_trial
+
+
+def test_fetch_completed_trials_from_view(hacked_exp, exp_config, random_dt):
+    """Fetch a list of the unseen yet completed trials."""
+    experiment_view = ExperimentView(hacked_exp.name)
+    experiment_view._experiment = hacked_exp
+
+    trials = experiment_view.fetch_completed_trials()
+    assert experiment_view._experiment._last_fetched == random_dt
+    assert len(trials) == 3
+    assert trials[0].to_dict() == exp_config[1][0]
+    assert trials[1].to_dict() == exp_config[1][1]
+    assert trials[2].to_dict() == exp_config[1][2]
+
+
+def test_view_is_done_property(hacked_exp):
+    """Check experiment stopping conditions accessed from view."""
+    experiment_view = ExperimentView(hacked_exp.name)
+    experiment_view._experiment = hacked_exp
+
+    assert experiment_view.is_done is False
+
+    with pytest.raises(AttributeError):
+        experiment_view.max_trials = 2
+
+    hacked_exp.max_trials = 2
+
+    assert experiment_view.is_done is True
+
+
+def test_experiment_view_stats(hacked_exp, exp_config, random_dt):
+    """Check that property stats from view is consistent."""
+    experiment_view = ExperimentView(hacked_exp.name)
+    experiment_view._experiment = hacked_exp
+
+    stats = experiment_view.stats
+    assert stats['trials_completed'] == 3
+    assert stats['best_trials_id'] == exp_config[1][1]['_id']
+    assert stats['best_evaluation'] == 2
+    assert stats['start_time'] == exp_config[0][2]['metadata']['datetime']
+    assert stats['finish_time'] == exp_config[1][2]['end_time']
+    assert stats['duration'] == stats['finish_time'] - stats['start_time']
+    assert len(stats) == 6
+
+
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_experiment_view_db_read_only():
+    """Verify that wrapper experiments' database is read-only"""
+    exp = ExperimentView('supernaedo2')
+
+    # Test that database.write indeed exists
+    exp._experiment._db._database.write
+    with pytest.raises(AttributeError):
+        exp._experiment._db.write

--- a/tests/unittests/core/test_producer.py
+++ b/tests/unittests/core/test_producer.py
@@ -10,7 +10,7 @@ from orion.core.worker.producer import Producer
 def producer(hacked_exp, random_dt, exp_config):
     """Return a setup `Producer`."""
     # make init done
-    hacked_exp.configure(exp_config[0][2])
+    hacked_exp.configure(exp_config[0][3])
     # insert fake point
     fake_point = ('gru', 'rnn')
     assert fake_point in hacked_exp.space


### PR DESCRIPTION
Why:

With experiment version control there is the possibility of having many
experiments instantiated at the same time but only one should be
editable, the main one. All the others should not be able to make
modifications in the database. This commit is an attempt at reducing
write errors by wrapping the experiment with a read-only wrapper which
defines which attributes can be accessed and which not.

Note:

It will still be possible to access the write methods of the experiment,
by explicitly fetching it with by accessing the sub attribute of the
wrapper (ex: experiment_view._experiment.register_trials()).
Nonetheless the current wrapper makes it less likely to do so by error.

How:

Create an empty class with a valid_attributes. list which defines which
attribute and method may be accessed. The method .__getattr__ filters out
the request on the wrapper based on valid_attributes.

The property is_done is slightly modified in the view since
experiment.is_done would normally do a write on the database. If
wrapper.is_done returns True, it will not update the database like the
normal experiment would.