### PR TITLE
Remove status attribute from Experiment

### DIFF
--- a/src/orion/client/manual.py
+++ b/src/orion/client/manual.py
@@ -49,7 +49,7 @@ def insert_trials(experiment_name, points, cmdconfig=None, raise_exc=True):
 
     experiment = Experiment(experiment_name)
     # Configuration is completely taken from the database
-    if experiment._id is None:
+    if experiment.id is None:
         raise ValueError("No experiment named '{}' could be found.".format(experiment_name))
     experiment.configure(experiment.configuration)
 

--- a/src/orion/client/manual.py
+++ b/src/orion/client/manual.py
@@ -49,7 +49,7 @@ def insert_trials(experiment_name, points, cmdconfig=None, raise_exc=True):
 
     experiment = Experiment(experiment_name)
     # Configuration is completely taken from the database
-    if experiment.status is None:
+    if experiment._id is None:
         raise ValueError("No experiment named '{}' could be found.".format(experiment_name))
     experiment.configure(experiment.configuration)
 

--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -152,7 +152,6 @@ def create_experiment(exp_name, expconfig, cmdconfig, cmdargs):
     # Pop out configuration concerning databases and resources
     expconfig.pop('database', None)
     expconfig.pop('resources', None)
-    expconfig.pop('status', None)
 
     log.info(expconfig)
 

--- a/src/orion/core/cli/init_only.py
+++ b/src/orion/core/cli/init_only.py
@@ -128,7 +128,6 @@ def create_experiment(exp_name, expconfig, cmdconfig, cmdargs):
     # Pop out configuration concerning databases and resources
     expconfig.pop('database', None)
     expconfig.pop('resources', None)
-    expconfig.pop('status', None)
 
     # Finish experiment's configuration and write it to database.
     try:

--- a/src/orion/core/cli/insert.py
+++ b/src/orion/core/cli/insert.py
@@ -66,7 +66,7 @@ def _execute(cmd_args, file_config):
     command_line_user_args = cmd_args['metadata'].pop('user_args', None)
     experiment = _infer_experiment(cmd_args, file_config)
 
-    if experiment._id is None:
+    if experiment.id is None:
         raise ValueError("No experiment with given name '%s' for user '%s' inside database, "
                          "can't insert." % (experiment.name, experiment.metadata['user']))
 

--- a/src/orion/core/cli/insert.py
+++ b/src/orion/core/cli/insert.py
@@ -66,7 +66,7 @@ def _execute(cmd_args, file_config):
     command_line_user_args = cmd_args['metadata'].pop('user_args', None)
     experiment = _infer_experiment(cmd_args, file_config)
 
-    if experiment.status is None:
+    if experiment._id is None:
         raise ValueError("No experiment with given name '%s' for user '%s' inside database, "
                          "can't insert." % (experiment.name, experiment.metadata['user']))
 
@@ -205,7 +205,6 @@ def create_experiment(exp_name, expconfig, file_config, cmd_args):
     # Pop out configuration concerning databases and resources
     expconfig.pop('database', None)
     expconfig.pop('resources', None)
-    expconfig.pop('status', None)
 
     log.info(expconfig)
 

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -31,6 +31,9 @@ class Experiment(object):
     ----------
     name : str
        Unique identifier for this experiment per `user`.
+    id: object
+       id of the experiment in the database if experiment is configured. Value is `None`
+       if the experiment is not configured.
     refers : dict or list of `Experiment` objects, after initialization is done.
        A dictionary pointing to a past `Experiment` name, ``refers[name]``, whose
        trials we want to add in the history of completed trials we want to re-use.
@@ -231,6 +234,15 @@ class Experiment(object):
         self._last_fetched = datetime.datetime.utcnow()
 
         return completed_trials
+
+    # pylint: disable=invalid-name
+    @property
+    def id(self):
+        """Id of the experiment in the database if configured.
+
+        Value is `None` if the experiment is not configured.
+        """
+        return self._id
 
     @property
     def is_done(self):

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -44,17 +44,6 @@ class Experiment(object):
        This attribute can be updated if the rest of the experiment configuration
        is the same. In that case, if trying to set to an already set experiment,
        it will overwrite the previous one.
-    status : str
-       A keyword among {*'pending'*, *'done'*, *'broken'*} indicating
-       how **Oríon** considers the current `Experiment`. This attribute cannot
-       be set from an orion configuration.
-
-       * 'pending' : Denotes an experiment with valid configuration which is
-          currently being handled by **Oríon**.
-       * 'done' : Denotes an experiment which has completed `max_trials` number
-          of parameter evaluations and is not *pending*.
-       * 'broken' : Denotes an experiment which stopped unsuccessfully due to
-          unexpected behaviour.
     algorithms : dict of dicts or an `PrimaryAlgo` object, after initialization is done.
        Complete specification of the optimization and dynamical procedures taking
        place in this `Experiment`.
@@ -83,9 +72,8 @@ class Experiment(object):
     """
 
     __slots__ = ('name', 'refers', 'metadata', 'pool_size', 'max_trials',
-                 'status', 'algorithms', '_db', '_init_done', '_id', '_last_fetched')
-    # 'status' should not be in config
-    non_forking_attrs = ('status', 'pool_size', 'max_trials')
+                 'algorithms', '_db', '_init_done', '_id', '_last_fetched')
+    non_forking_attrs = ('pool_size', 'max_trials')
 
     def __init__(self, name):
         """Initialize an Experiment object with primary key (:attr:`name`, :attr:`user`).
@@ -114,7 +102,6 @@ class Experiment(object):
         self.metadata = {'user': user, 'datetime': stamp}
         self.pool_size = None
         self.max_trials = None
-        self.status = None
         self.algorithms = None
 
         config = self._db.read('experiments',
@@ -140,7 +127,6 @@ class Experiment(object):
                               [('name', Database.ASCENDING),
                                ('metadata.user', Database.ASCENDING)],
                               unique=True)
-        self._db.ensure_index('experiments', 'status')
 
         self._db.ensure_index('trials', 'experiment')
         self._db.ensure_index('trials', 'status')
@@ -261,12 +247,8 @@ class Experiment(object):
             )
         num_completed_trials = self._db.count('trials', query)
 
-        if num_completed_trials >= self.max_trials or \
-                (self._init_done and self.algorithms.is_done):
-            self._db.write('experiments', {'status': 'done'}, {'_id': self._id})
-            return True
-
-        return False
+        return ((num_completed_trials >= self.max_trials) or
+                (self._init_done and self.algorithms.is_done))
 
     @property
     def space(self):
@@ -313,12 +295,11 @@ class Experiment(object):
         experiment._instantiate_config(self.configuration)
         experiment._instantiate_config(config)
         experiment._init_done = True
-        experiment.status = 'pending'
 
-        # If status is None in this object, then database did not hit a config
+        # If id is None in this object, then database did not hit a config
         # with same (name, user's name) pair. Everything depends on the user's
         # orion_config to set.
-        if self.status is None:
+        if self._id is None:
             if config['name'] != self.name or \
                     config['metadata']['user'] != self.metadata['user'] or \
                     config['metadata']['datetime'] != self.metadata['datetime']:
@@ -334,7 +315,6 @@ class Experiment(object):
         self._instantiate_config(final_config)
 
         self._init_done = True
-        self.status = 'pending'
 
         # If everything is alright, push new config to database
         if is_new:
@@ -421,8 +401,6 @@ class Experiment(object):
         """
         # Just overwrite everything else given
         for section, value in config.items():
-            if section == 'status':
-                continue
             if section not in self.__slots__:
                 log.warning("Found section '%s' in configuration. Experiments "
                             "do not support this option. Ignoring.", section)

--- a/tests/functional/commands/experiment.yaml
+++ b/tests/functional/commands/experiment.yaml
@@ -25,7 +25,6 @@
         value:
   pool_size: 2
   max_trials: 1000
-  status: running
   algorithms:
     random: {}
 
@@ -49,7 +48,6 @@
         value:
   pool_size: 2
   max_trials: 1000
-  status: running
   algorithms:
     random: {}
 
@@ -73,6 +71,5 @@
         value:
   pool_size: 2
   max_trials: 1000
-  status: running
   algorithms: 
     random: {}

--- a/tests/functional/demo/test_demo.py
+++ b/tests/functional/demo/test_demo.py
@@ -32,7 +32,6 @@ def test_demo_with_default_algo_cli_config_only(database, monkeypatch):
     assert exp['name'] == 'default_algo'
     assert exp['pool_size'] == 10
     assert exp['max_trials'] == 30
-    assert exp['status'] == 'done'
     assert exp['algorithms'] == {'random': {}}
     assert 'user' in exp['metadata']
     assert 'datetime' in exp['metadata']
@@ -58,7 +57,6 @@ def test_demo(database, monkeypatch):
     assert exp['name'] == 'voila_voici'
     assert exp['pool_size'] == 1
     assert exp['max_trials'] == 100
-    assert exp['status'] == 'done'
     assert exp['algorithms'] == {'gradient_descent': {'learning_rate': 0.1,
                                                       'dx_tolerance': 1e-7}}
     assert 'user' in exp['metadata']
@@ -110,7 +108,6 @@ def test_demo_two_workers(database, monkeypatch):
     assert exp['name'] == 'two_workers_demo'
     assert exp['pool_size'] == 2
     assert exp['max_trials'] == 400
-    assert exp['status'] == 'done'
     assert exp['algorithms'] == {'random': {}}
     assert 'user' in exp['metadata']
     assert 'datetime' in exp['metadata']
@@ -162,7 +159,6 @@ def test_workon(database):
     assert exp['name'] == 'voila_voici'
     assert exp['pool_size'] == 1
     assert exp['max_trials'] == 100
-    assert exp['status'] == 'done'
     assert exp['algorithms'] == {'gradient_descent': {'learning_rate': 0.1,
                                                       'dx_tolerance': 1e-7}}
     assert 'user' in exp['metadata']

--- a/tests/unittests/core/experiment.yaml
+++ b/tests/unittests/core/experiment.yaml
@@ -38,9 +38,6 @@
   pool_size: 2
   max_trials: 1000
 
-  # functional info
-  status: completed  # pending, done, broken
-
   # **complete** specification of algorithms used
   # user's configuration, but defaults are inferred
   algorithms:
@@ -71,7 +68,6 @@
         value: gru
   pool_size: 2
   max_trials: 1000
-  status: broken
   algorithms:
     dumbalgo:  # this must be logged as `Experiment` would log it, complete specification
       value: 5
@@ -100,7 +96,6 @@
         value: gru
   pool_size: 2
   max_trials: 1000
-  status: running
   algorithms:
     dumbalgo:  # this must be logged as `Experiment` would log it, complete specification
       value: 5

--- a/tests/unittests/core/mongodb_test.py
+++ b/tests/unittests/core/mongodb_test.py
@@ -170,17 +170,17 @@ class TestEnsureIndex(object):
 
     def test_new_index(self, orion_db):
         """Index should be added to mongo database"""
-        assert "status_1" not in orion_db._db.experiments.index_information()
-        orion_db.ensure_index('experiments', 'status')
-        assert "status_1" in orion_db._db.experiments.index_information()
+        assert "status_1" not in orion_db._db.trials.index_information()
+        orion_db.ensure_index('trials', 'status')
+        assert "status_1" in orion_db._db.trials.index_information()
 
     def test_existing_index(self, orion_db):
         """Index should be added to mongo database and reattempt should do nothing"""
-        assert "status_1" not in orion_db._db.experiments.index_information()
-        orion_db.ensure_index('experiments', 'status')
-        assert "status_1" in orion_db._db.experiments.index_information()
-        orion_db.ensure_index('experiments', 'status')
-        assert "status_1" in orion_db._db.experiments.index_information()
+        assert "status_1" not in orion_db._db.trials.index_information()
+        orion_db.ensure_index('trials', 'status')
+        assert "status_1" in orion_db._db.trials.index_information()
+        orion_db.ensure_index('trials', 'status')
+        assert "status_1" in orion_db._db.trials.index_information()
 
     def test_ordered_index(self, orion_db):
         """Sort order should be added to index"""
@@ -343,8 +343,8 @@ class TestReadAndWrite(object):
         loaded_config = orion_db.read_and_write(
             'experiments',
             {'name': 'supernaedo2', 'metadata.user': 'dendi'},
-            {'status': 'lalala'})
-        exp_config[0][2]['status'] = 'lalala'
+            {'pool_size': 'lalala'})
+        exp_config[0][2]['pool_size'] = 'lalala'
         assert loaded_config == exp_config[0][2]
 
     def test_read_and_write_many(self, database, orion_db, exp_config):
@@ -357,22 +357,22 @@ class TestReadAndWrite(object):
         loaded_config = orion_db.read_and_write(
             'experiments',
             {'name': 'supernaedo2'},
-            {'status': 'lalala'})
+            {'pool_size': 'lalala'})
 
-        exp_config[0][0]['status'] = 'lalala'
+        exp_config[0][0]['pool_size'] = 'lalala'
         assert loaded_config == exp_config[0][0]
 
         # Make sure it only changed the first document found
         documents = orion_db.read('experiments', {'name': 'supernaedo2'})
-        assert documents[0]['status'] == 'lalala'
-        assert documents[1]['status'] != 'lalala'
+        assert documents[0]['pool_size'] == 'lalala'
+        assert documents[1]['pool_size'] != 'lalala'
 
     def test_read_and_write_no_match(self, database, orion_db):
         """Should return None when there is no match."""
         loaded_config = orion_db.read_and_write(
             'experiments',
             {'name': 'lalala'},
-            {'status': 'lalala'})
+            {'pool_size': 'lalala'})
 
         assert loaded_config is None
 


### PR DESCRIPTION
Why:

The status is not useful since properties is_done and
is_broken (coming soon) can be used to verify the state
of the experiment. As the status can be inferred, and experiments
are not very likely to be queried based on status (in opposition
to trials which are often queried based on status), there is
no reason to maintain a status attribute.

How:

Replace tests on status (which all had the function of testing if an
experiment is configured or found in DB) with test on _id.