### PR TITLE
Feature/evc experiment builder

### DIFF
--- a/src/orion/core/cli/__init__.py
+++ b/src/orion/core/cli/__init__.py
@@ -16,12 +16,6 @@ from orion.core.cli.base import OrionArgsParser
 
 log = logging.getLogger(__name__)
 
-CLI_DOC_HEADER = """
-orion:
-  Orion cli script for asynchronous distributed optimization
-
-"""
-
 
 def load_modules_parser(orion_parser):
     """Search through the `cli` folder for any module containing a `add_subparser` function"""
@@ -44,7 +38,7 @@ def main(argv=None):
     # Fetch experiment name, user's script path and command line arguments
     # Use `-h` option to show help
 
-    orion_parser = OrionArgsParser(CLI_DOC_HEADER)
+    orion_parser = OrionArgsParser()
 
     load_modules_parser(orion_parser)
 

--- a/src/orion/core/cli/__init__.py
+++ b/src/orion/core/cli/__init__.py
@@ -12,7 +12,7 @@
 import logging
 import os
 
-from orion.core.cli import resolve_config
+from orion.core.cli.base import OrionArgsParser
 
 log = logging.getLogger(__name__)
 
@@ -21,20 +21,6 @@ orion:
   Orion cli script for asynchronous distributed optimization
 
 """
-
-
-def main(argv=None):
-    """Entry point for `orion.core` functionality."""
-    # Fetch experiment name, user's script path and command line arguments
-    # Use `-h` option to show help
-
-    orion_parser = resolve_config.OrionArgsParser(CLI_DOC_HEADER)
-
-    load_modules_parser(orion_parser)
-
-    orion_parser.execute(argv)
-
-    return 0
 
 
 def load_modules_parser(orion_parser):
@@ -51,6 +37,20 @@ def load_modules_parser(orion_parser):
         if hasattr(module, 'add_subparser'):
             add_subparser = getattr(module, 'add_subparser')
             add_subparser(orion_parser.get_subparsers())
+
+
+def main(argv=None):
+    """Entry point for `orion.core` functionality."""
+    # Fetch experiment name, user's script path and command line arguments
+    # Use `-h` option to show help
+
+    orion_parser = OrionArgsParser(CLI_DOC_HEADER)
+
+    load_modules_parser(orion_parser)
+
+    orion_parser.execute(argv)
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.cli` -- Base class and function utilities for cli
+==================================================================
+
+.. module:: cli
+   :platform: Unix
+   :synopsis: Orion main parser class and helper functions to parse command-line options
+
+"""
+import argparse
+import logging
+import textwrap
+
+import orion
+
+
+class OrionArgsParser:
+    """Parser object handling the upper-level parsing of Oríon's arguments."""
+
+    def __init__(self, description):
+        """Create the pre-command arguments"""
+        self.description = description
+
+        self.parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=textwrap.dedent(description))
+
+        self.parser.add_argument(
+            '-V', '--version',
+            action='version', version='orion ' + orion.core.__version__)
+
+        self.parser.add_argument(
+            '-v', '--verbose',
+            action='count', default=0,
+            help="logging levels of information about the process (-v: INFO. -vv: DEBUG)")
+
+        self.subparsers = self.parser.add_subparsers(help='sub-command help')
+
+    def get_subparsers(self):
+        """Return the subparser object for this parser."""
+        return self.subparsers
+
+    def parse(self, argv):
+        """Call argparse and generate a dictionary of arguments' value"""
+        args = vars(self.parser.parse_args(argv))
+
+        verbose = args.pop('verbose', 0)
+        if verbose == 1:
+            logging.basicConfig(level=logging.INFO)
+        elif verbose == 2:
+            logging.basicConfig(level=logging.DEBUG)
+
+        function = args.pop('func')
+        return args, function
+
+    def execute(self, argv):
+        """Execute main function of the subparser"""
+        args, function = self.parse(argv)
+        function(args)
+
+
+def get_basic_args_group(parser):
+    """Return the basic arguments for any command."""
+    basic_args_group = parser.add_argument_group(
+        "Oríon arguments (optional)",
+        description="These arguments determine orion's behaviour")
+
+    basic_args_group.add_argument(
+        '-n', '--name',
+        type=str, metavar='stringID',
+        help="experiment's unique name; "
+             "(default: None - specified either here or in a config)")
+
+    basic_args_group.add_argument('-c', '--config', type=argparse.FileType('r'),
+                                  metavar='path-to-config', help="user provided "
+                                  "orion configuration file")
+
+    return basic_args_group
+
+
+def get_user_args_group(parser):
+    """
+    Return the user group arguments for any command.
+    User group arguments are composed of the user script and the user args
+    """
+    usergroup = parser.add_argument_group(
+        "User script related arguments",
+        description="These arguments determine user's script behaviour "
+                    "and they can serve as orion's parameter declaration.")
+
+    usergroup.add_argument(
+        'user_script', type=str, metavar='path-to-script',
+        help="your experiment's script")
+
+    usergroup.add_argument(
+        'user_args', nargs=argparse.REMAINDER, metavar='...',
+        help="Command line arguments to your script (if any). A configuration "
+             "file intended to be used with 'userscript' must be given as a path "
+             "in the **first positional** argument OR using `--config=<path>` "
+             "keyword argument.")
+
+    return usergroup

--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -15,10 +15,17 @@ import textwrap
 import orion
 
 
+CLI_DOC_HEADER = """
+orion:
+  Orion cli script for asynchronous distributed optimization
+
+"""
+
+
 class OrionArgsParser:
     """Parser object handling the upper-level parsing of Oríon's arguments."""
 
-    def __init__(self, description):
+    def __init__(self, description=CLI_DOC_HEADER):
         """Create the pre-command arguments"""
         self.description = description
 

--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -14,7 +14,8 @@ import logging
 import os
 
 import orion
-from orion.core.cli import resolve_config
+from orion.core.io import resolve_config
+from orion.core.cli import base as cli
 from orion.core.io.database import Database, DuplicateKeyError
 from orion.core.worker import workon
 from orion.core.worker.experiment import Experiment
@@ -26,7 +27,7 @@ def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
     hunt_parser = parser.add_parser('hunt', help='hunt help')
 
-    orion_group = resolve_config.get_basic_args_group(hunt_parser)
+    orion_group = cli.get_basic_args_group(hunt_parser)
 
     orion_group.add_argument(
         '--max-trials', type=int, metavar='#',
@@ -38,7 +39,7 @@ def add_subparser(parser):
         help="number of concurrent workers to evaluate candidate samples "
              "(default: %s)" % resolve_config.DEF_CMD_POOL_SIZE[1])
 
-    resolve_config.get_user_args_group(hunt_parser)
+    cli.get_user_args_group(hunt_parser)
 
     hunt_parser.set_defaults(func=main)
 

--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -11,9 +11,7 @@
 """
 
 import logging
-import os
 
-import orion
 from orion.core.cli import base as cli
 from orion.core.io import resolve_config
 from orion.core.io.experiment_builder import ExperimentBuilder
@@ -46,32 +44,6 @@ def add_subparser(parser):
 
 
 def main(args):
-    """Fetch config and execute hunt command"""
-    # Note: Side effects on args
-    set_metadata(args)
-
-    _execute(args)
-
-
-def set_metadata(args):
-    """Set metadata from command line arguments."""
-    # Explicitly add orion's version as experiment's metadata
-    args['metadata'] = dict()
-    args['metadata']['orion_version'] = orion.core.__version__
-    log.debug("Using orion version %s", args['metadata']['orion_version'])
-
-    # Move 'user_script' and 'user_args' to 'metadata' key
-    user_script = args.pop('user_script')
-    abs_user_script = os.path.abspath(user_script)
-    if resolve_config.is_exe(abs_user_script):
-        user_script = abs_user_script
-
-    args['metadata']['user_script'] = user_script
-    args['metadata']['user_args'] = args.pop('user_args')
-    log.debug("Problem definition: %s %s", args['metadata']['user_script'],
-              ' '.join(args['metadata']['user_args']))
-
-
-def _execute(cmdargs):
-    experiment = ExperimentBuilder().build_from(cmdargs)
+    """Build experiment and execute hunt command"""
+    experiment = ExperimentBuilder().build_from(args)
     workon(experiment)

--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -14,11 +14,10 @@ import logging
 import os
 
 import orion
-from orion.core.io import resolve_config
 from orion.core.cli import base as cli
-from orion.core.io.database import Database, DuplicateKeyError
+from orion.core.io import resolve_config
+from orion.core.io.experiment_builder import ExperimentBuilder
 from orion.core.worker import workon
-from orion.core.worker.experiment import Experiment
 
 log = logging.getLogger(__name__)
 
@@ -49,19 +48,17 @@ def add_subparser(parser):
 def main(args):
     """Fetch config and execute hunt command"""
     # Note: Side effects on args
-    config = fetch_config(args)
+    set_metadata(args)
 
-    _execute(args, config)
+    _execute(args)
 
 
-def fetch_config(args):
-    """Get options from command line arguments."""
+def set_metadata(args):
+    """Set metadata from command line arguments."""
     # Explicitly add orion's version as experiment's metadata
     args['metadata'] = dict()
     args['metadata']['orion_version'] = orion.core.__version__
     log.debug("Using orion version %s", args['metadata']['orion_version'])
-
-    config = resolve_config.fetch_config(args)
 
     # Move 'user_script' and 'user_args' to 'metadata' key
     user_script = args.pop('user_script')
@@ -74,105 +71,7 @@ def fetch_config(args):
     log.debug("Problem definition: %s %s", args['metadata']['user_script'],
               ' '.join(args['metadata']['user_args']))
 
-    return config
 
-
-def _execute(cmdargs, cmdconfig):
-    experiment = _infer_experiment(cmdargs, cmdconfig)
+def _execute(cmdargs):
+    experiment = ExperimentBuilder().build_from(cmdargs)
     workon(experiment)
-
-
-def _infer_experiment(cmdargs, cmdconfig):
-    # Initialize configuration dictionary.
-    # Fetch info from defaults and configurations from default locations.
-    expconfig = resolve_config.fetch_default_options()
-
-    # Fetch orion system variables (database and resource information)
-    # See :const:`orion.core.io.resolve_config.ENV_VARS` for environmental
-    # variables used
-    expconfig = resolve_config.merge_env_vars(expconfig)
-
-    # Initialize singleton database object
-    tmpconfig = resolve_config.merge_orion_config(expconfig, dict(),
-                                                  cmdconfig, cmdargs)
-
-    db_opts = tmpconfig['database']
-    dbtype = db_opts.pop('type')
-
-    log.debug("Creating %s database client with args: %s", dbtype, db_opts)
-    Database(of_type=dbtype, **db_opts)
-
-    # Information should be enough to infer experiment's name.
-    exp_name = tmpconfig['name']
-    if exp_name is None:
-        raise RuntimeError("Could not infer experiment's name. "
-                           "Please use either `name` cmd line arg or provide "
-                           "one in orion's configuration file.")
-
-    experiment = create_experiment(exp_name, expconfig, cmdconfig, cmdargs)
-
-    return experiment
-
-
-def create_experiment(exp_name, expconfig, cmdconfig, cmdargs):
-    """Create an experiment based on configuration.
-
-    Configuration is a combination of command line, experiment configuration
-    file, experiment configuration in database and orion configuration files.
-
-    Precedence of configurations is:
-    `cmdargs` > `cmdconfig` > `dbconfig` > `expconfig`
-
-    This means `expconfig` values would be overwritten by `dbconfig` and so on.
-
-    Parameters
-    ----------
-    exp_name: str
-        Name of the experiment
-    expconfig: dict
-        Configuration coming from default configuration files.
-    cmdconfig: dict
-        Configuration coming from configuration file.
-    cmdargs: dict
-        Configuration coming from command line arguments.
-
-    """
-    # Initialize experiment object.
-    # Check for existing name and fetch configuration.
-    experiment = Experiment(exp_name)
-    dbconfig = experiment.configuration
-
-    log.debug("DB config")
-    log.debug(dbconfig)
-
-    expconfig = resolve_config.merge_orion_config(expconfig, dbconfig,
-                                                  cmdconfig, cmdargs)
-    # Infer rest information about the process + versioning
-    expconfig['metadata'] = infer_versioning_metadata(expconfig['metadata'])
-
-    # Pop out configuration concerning databases and resources
-    expconfig.pop('database', None)
-    expconfig.pop('resources', None)
-
-    log.info(expconfig)
-
-    # Finish experiment's configuration and write it to database.
-    try:
-        experiment.configure(expconfig)
-    except DuplicateKeyError:
-        # Fails if concurrent experiment with identical (name, metadata.user)
-        # is written first in the database.
-        # Next infer_experiment() should either load experiment from database
-        # and run smoothly if identical or trigger an experiment fork.
-        # In other words, there should not be more than 1 level of recursion.
-        experiment = create_experiment(exp_name, expconfig, cmdconfig, cmdargs)
-
-    return experiment
-
-
-def infer_versioning_metadata(existing_metadata):
-    """Infer information about user's script versioning if available."""
-    # VCS system
-    # User repo's version
-    # User repo's HEAD commit hash
-    return existing_metadata

--- a/src/orion/core/cli/init_only.py
+++ b/src/orion/core/cli/init_only.py
@@ -11,7 +11,6 @@
 
 import logging
 
-import orion
 from orion.core.cli import base as cli
 from orion.core.io.experiment_builder import ExperimentBuilder
 
@@ -32,23 +31,6 @@ def add_subparser(parser):
 
 
 def main(args):
-    """Set metadata and initialize experiment"""
-    set_metadata(args)
-
-    _execute(args)
-
-
-def set_metadata(args):
-    """Set metadata from command line arguments."""
-    # Explicitly add orion's version as experiment's metadata
-    args['metadata'] = dict()
-    args['metadata']['orion_version'] = orion.core.__version__
-    log.debug("Using orion version %s", args['metadata']['orion_version'])
-
-    args.pop('user_script')
-    args['metadata']['user_args'] = args.pop('user_args')
-
-
-# By building the experiment, we create a new experiment document in database
-def _execute(cmdargs):
-    ExperimentBuilder().build_from(cmdargs)
+    """Build and initialize experiment"""
+    # By building the experiment, we create a new experiment document in database
+    ExperimentBuilder().build_from(args)

--- a/src/orion/core/cli/init_only.py
+++ b/src/orion/core/cli/init_only.py
@@ -12,10 +12,8 @@
 import logging
 
 import orion
-from orion.core.io import resolve_config
 from orion.core.cli import base as cli
-from orion.core.io.database import Database, DuplicateKeyError
-from orion.core.worker.experiment import Experiment
+from orion.core.io.experiment_builder import ExperimentBuilder
 
 log = logging.getLogger(__name__)
 
@@ -34,119 +32,23 @@ def add_subparser(parser):
 
 
 def main(args):
-    """Fetch config and initialize experiment"""
-    # Note: Side effects on args
-    config = fetch_config(args)
+    """Set metadata and initialize experiment"""
+    set_metadata(args)
 
-    _execute(args, config)
+    _execute(args)
 
 
-def fetch_config(args):
-    """Create the dictionary of modified args for the execution of the command"""
+def set_metadata(args):
+    """Set metadata from command line arguments."""
     # Explicitly add orion's version as experiment's metadata
     args['metadata'] = dict()
     args['metadata']['orion_version'] = orion.core.__version__
     log.debug("Using orion version %s", args['metadata']['orion_version'])
 
-    config = resolve_config.fetch_config(args)
-
     args.pop('user_script')
     args['metadata']['user_args'] = args.pop('user_args')
 
-    return config
 
-
-# By inferring the experiment, we create a new configured experiment
-def _execute(cmdargs, cmdconfig):
-    _infer_experiment(cmdargs, cmdconfig)
-
-
-def _infer_experiment(cmdargs, cmdconfig):
-    # Initialize configuration dictionary.
-    # Fetch info from defaults and configurations from default locations.
-    expconfig = resolve_config.fetch_default_options()
-
-    # Fetch orion system variables (database and resource information)
-    # See :const:`orion.core.io.resolve_config.ENV_VARS` for environmental
-    # variables used
-    expconfig = resolve_config.merge_env_vars(expconfig)
-
-    # Initialize singleton database object
-    tmpconfig = resolve_config.merge_orion_config(expconfig, dict(),
-                                                  cmdconfig, cmdargs)
-    db_opts = tmpconfig['database']
-    dbtype = db_opts.pop('type')
-
-    log.debug("Creating %s database client with args: %s", dbtype, db_opts)
-    Database(of_type=dbtype, **db_opts)
-
-    # Information should be enough to infer experiment's name.
-    exp_name = tmpconfig['name']
-    if exp_name is None:
-        raise RuntimeError("Could not infer experiment's name. "
-                           "Please use either `name` cmd line arg or provide "
-                           "one in orion's configuration file.")
-
-    experiment = create_experiment(exp_name, expconfig, cmdconfig, cmdargs)
-
-    return experiment
-
-
-def create_experiment(exp_name, expconfig, cmdconfig, cmdargs):
-    """Create an experiment based on configuration.
-
-    Configuration is a combination of command line, experiment configuration
-    file, experiment configuration in database and orion configuration files.
-
-    Precedence of configurations is:
-    `cmdargs` > `cmdconfig` > `dbconfig` > `expconfig`
-
-    This means `expconfig` values would be overwritten by `dbconfig` and so on.
-
-    Parameters
-    ----------
-    exp_name: str
-        Name of the experiment
-    expconfig: dict
-        Configuration coming from default configuration files.
-    cmdconfig: dict
-        Configuration coming from configuration file.
-    cmdargs: dict
-        Configuration coming from command line arguments.
-
-    """
-    # Initialize experiment object.
-    # Check for existing name and fetch configuration.
-    experiment = Experiment(exp_name)
-    dbconfig = experiment.configuration
-
-    expconfig = resolve_config.merge_orion_config(expconfig, dbconfig,
-                                                  cmdconfig, cmdargs)
-
-    # Infer rest information about the process + versioning
-    expconfig['metadata'] = infer_versioning_metadata(expconfig['metadata'])
-
-    # Pop out configuration concerning databases and resources
-    expconfig.pop('database', None)
-    expconfig.pop('resources', None)
-
-    # Finish experiment's configuration and write it to database.
-    try:
-        experiment.configure(expconfig)
-    except DuplicateKeyError:
-        # Fails if concurrent experiment with identical (name, metadata.user)
-        # is written first in the database.
-        # Next infer_experiment() should either load experiment from database
-        # and run smoothly if identical or trigger an experiment fork.
-        # In other words, there should not be more than 1 level of recursion.
-        experiment = create_experiment(exp_name, expconfig, cmdconfig, cmdargs)
-
-    return experiment
-
-
-def infer_versioning_metadata(existing_metadata):
-    """Infer information about user's script versioning if available."""
-    # VCS system
-    # User repo's version
-    # User repo's HEAD commit hash
-    return existing_metadata
+# By building the experiment, we create a new experiment document in database
+def _execute(cmdargs):
+    ExperimentBuilder().build_from(cmdargs)

--- a/src/orion/core/cli/init_only.py
+++ b/src/orion/core/cli/init_only.py
@@ -12,7 +12,8 @@
 import logging
 
 import orion
-from orion.core.cli import resolve_config
+from orion.core.io import resolve_config
+from orion.core.cli import base as cli
 from orion.core.io.database import Database, DuplicateKeyError
 from orion.core.worker.experiment import Experiment
 
@@ -23,9 +24,9 @@ def add_subparser(parser):
     """Return the parser that needs to be used for this command"""
     init_only_parser = parser.add_parser('init_only', help='init_only help')
 
-    resolve_config.get_basic_args_group(init_only_parser)
+    cli.get_basic_args_group(init_only_parser)
 
-    resolve_config.get_user_args_group(init_only_parser)
+    cli.get_user_args_group(init_only_parser)
 
     init_only_parser.set_defaults(func=main)
 

--- a/src/orion/core/cli/insert.py
+++ b/src/orion/core/cli/insert.py
@@ -16,7 +16,8 @@ import os
 import re
 
 import orion
-from orion.core.cli import resolve_config
+from orion.core.io import resolve_config
+from orion.core.cli import base as cli
 from orion.core.io.convert import infer_converter_from_file_type
 from orion.core.io.database import Database
 from orion.core.io.space_builder import SpaceBuilder
@@ -30,9 +31,9 @@ def add_subparser(parser):
     """Add the subparser that needs to be used for this command"""
     insert_parser = parser.add_parser('insert', help='insert help')
 
-    resolve_config.get_basic_args_group(insert_parser)
+    cli.get_basic_args_group(insert_parser)
 
-    resolve_config.get_user_args_group(insert_parser)
+    cli.get_user_args_group(insert_parser)
 
     insert_parser.set_defaults(func=main)
 

--- a/src/orion/core/cli/insert.py
+++ b/src/orion/core/cli/insert.py
@@ -16,13 +16,10 @@ import os
 import re
 
 import orion
-from orion.core.io import resolve_config
 from orion.core.cli import base as cli
 from orion.core.io.convert import infer_converter_from_file_type
-from orion.core.io.database import Database
-from orion.core.io.space_builder import SpaceBuilder
+from orion.core.io.experiment_builder import ExperimentBuilder
 from orion.core.utils.format_trials import tuple_to_trial
-from orion.core.worker.experiment import Experiment
 
 log = logging.getLogger(__name__)
 
@@ -42,43 +39,34 @@ def add_subparser(parser):
 
 def main(args):
     """Fetch config and insert new point"""
-    # Note: Side effects on args
-    config = fetch_config(args)
+    set_metadata(args)
 
-    _execute(args, config)
+    _execute(args)
 
 
-def fetch_config(args):
-    """Get options from command line arguments."""
+def set_metadata(args):
+    """Set metadata from command line arguments."""
     # Explicitly add orion's version as experiment's metadata
     args['metadata'] = dict()
     args['metadata']['orion_version'] = orion.core.__version__
     log.debug("Using orion version %s", args['metadata']['orion_version'])
 
-    config = resolve_config.fetch_config(args)
-
     args.pop('user_script')
     args['metadata']['user_args'] = args.pop('user_args')
 
-    return config
 
-
-def _execute(cmd_args, file_config):
+def _execute(cmd_args):
     command_line_user_args = cmd_args['metadata'].pop('user_args', None)
-    experiment = _infer_experiment(cmd_args, file_config)
-
-    if experiment.id is None:
-        raise ValueError("No experiment with given name '%s' for user '%s' inside database, "
-                         "can't insert." % (experiment.name, experiment.metadata['user']))
+    experiment_view = ExperimentBuilder().build_view_from(cmd_args)
 
     transformed_args = _build_from(command_line_user_args)
-    exp_space = SpaceBuilder().build_from(experiment.configuration['metadata']['user_args'])
+    exp_space = experiment_view.space
 
     values = _create_tuple_from_values(transformed_args, exp_space)
 
     trial = tuple_to_trial(values, exp_space)
 
-    experiment.register_trials([trial])
+    ExperimentBuilder().build_from_config(experiment_view.configuration).register_trials([trial])
 
 
 def _validate_dimensions(transformed_args, exp_space):
@@ -133,91 +121,6 @@ def _create_tuple_from_values(transformed_args, exp_space):
             values.append(exp_space[namespace].default_value)
 
     return values
-
-
-def _infer_experiment(cmd_args, file_config):
-    # Initialize configuration dictionary.
-    # Fetch info from defaults and configurations from default locations.
-    expconfig = resolve_config.fetch_default_options()
-
-    # Fetch orion system variables (database and resource information)
-    # See :const:`orion.core.io.resolve_config.ENV_VARS` for environmental
-    # variables used
-    expconfig = resolve_config.merge_env_vars(expconfig)
-
-    # Initialize singleton database object
-    tmpconfig = resolve_config.merge_orion_config(expconfig, dict(),
-                                                  file_config, cmd_args)
-
-    db_opts = tmpconfig['database']
-    dbtype = db_opts.pop('type')
-
-    log.debug("Creating %s database client with args: %s", dbtype, db_opts)
-    Database(of_type=dbtype, **db_opts)
-
-    # Information should be enough to infer experiment's name.
-    exp_name = tmpconfig['name']
-    if exp_name is None:
-        raise RuntimeError("Could not infer experiment's name. "
-                           "Please use either `name` cmd line arg or provide "
-                           "one in orion's configuration file.")
-
-    experiment = create_experiment(exp_name, expconfig, file_config, cmd_args)
-
-    return experiment
-
-
-def create_experiment(exp_name, expconfig, file_config, cmd_args):
-    """Create an experiment based on configuration.
-
-    Configuration is a combination of command line, experiment configuration
-    file, experiment configuration in database and orion configuration files.
-
-    Precedence of configurations is:
-    `cmdargs` > `cmdconfig` > `dbconfig` > `expconfig`
-
-    This means `expconfig` values would be overwritten by `dbconfig` and so on.
-
-    Parameters
-    ----------
-    exp_name: str
-        Name of the experiment
-    expconfig: dict
-        Configuration coming from default configuration files.
-    cmdconfig: dict
-        Configuration coming from configuration file.
-    cmdargs: dict
-        Configuration coming from command line arguments.
-
-    """
-    # Initialize experiment object.
-    # Check for existing name and fetch configuration.
-    experiment = Experiment(exp_name)
-    dbconfig = experiment.configuration
-
-    log.debug("DB config")
-    log.debug(dbconfig)
-
-    expconfig = resolve_config.merge_orion_config(expconfig, dbconfig,
-                                                  file_config, cmd_args)
-    # Infer rest information about the process + versioning
-    expconfig['metadata'] = infer_versioning_metadata(expconfig['metadata'])
-
-    # Pop out configuration concerning databases and resources
-    expconfig.pop('database', None)
-    expconfig.pop('resources', None)
-
-    log.info(expconfig)
-
-    return experiment
-
-
-def infer_versioning_metadata(existing_metadata):
-    """Infer information about user's script versioning if available."""
-    # VCS system
-    # User repo's version
-    # User repo's HEAD commit hash
-    return existing_metadata
 
 
 def _build_from(cmd_args):

--- a/src/orion/core/cli/insert.py
+++ b/src/orion/core/cli/insert.py
@@ -15,7 +15,6 @@ import logging
 import os
 import re
 
-import orion
 from orion.core.cli import base as cli
 from orion.core.io.convert import infer_converter_from_file_type
 from orion.core.io.experiment_builder import ExperimentBuilder
@@ -39,25 +38,8 @@ def add_subparser(parser):
 
 def main(args):
     """Fetch config and insert new point"""
-    set_metadata(args)
-
-    _execute(args)
-
-
-def set_metadata(args):
-    """Set metadata from command line arguments."""
-    # Explicitly add orion's version as experiment's metadata
-    args['metadata'] = dict()
-    args['metadata']['orion_version'] = orion.core.__version__
-    log.debug("Using orion version %s", args['metadata']['orion_version'])
-
-    args.pop('user_script')
-    args['metadata']['user_args'] = args.pop('user_args')
-
-
-def _execute(cmd_args):
-    command_line_user_args = cmd_args['metadata'].pop('user_args', None)
-    experiment_view = ExperimentBuilder().build_view_from(cmd_args)
+    command_line_user_args = args.pop('user_args', None)
+    experiment_view = ExperimentBuilder().build_view_from(args)
 
     transformed_args = _build_from(command_line_user_args)
     exp_space = experiment_view.space

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -253,7 +253,6 @@ class ExperimentBuilder(object):
         # Pop out configuration concerning databases and resources
         config.pop('database', None)
         config.pop('resources', None)
-        config.pop('status', None)
 
         experiment = Experiment(config['name'])
 

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -1,0 +1,279 @@
+# -*- coding: utf-8 -*-
+# pylint:disable=protected-access
+"""
+:mod:`orion.core.io.experiment_builder` -- Create experiment from user options
+==============================================================================
+
+.. module:: experiment
+   :platform: Unix
+   :synopsis: Functions which build `Experiment` and `ExperimentView` objects
+       based on user configuration.
+
+
+The instantiation of an `Experiment` is not a trivial process when the user request an experiment
+with specific options. One can easily create a new experiment with
+`ExperimentView('some_experiment_name')`, but the configuration of a _writable_ experiment is less
+straighforward. This is because there is many sources of configuration and they have a strict
+hierarchy. From the more global to the more specific, there is:
+
+1. Global configuration:
+    Defined by `src.orion.core.io.resolve_config.DEF_CONFIG_FILES_PATHS`.
+    Can be scattered in user file system, defaults could look like:
+        - `/some/path/to/.virtualenvs/orion/share/orion.core`
+        - `/etc/xdg/xdg-ubuntu/orion.core`
+        - `/home/${USER}/.config/orion.core`
+
+    Note that some variables have default value even if user do not defined them in global
+    configuration:
+        - `max_trials = src.orion.core.io.resolve_config.DEF_CMD_MAX_TRIALS`
+        - `pool_size = src.orion.core.io.resolve_config.DEF_CMD_POOL_SIZE`
+        - `algorithms = random`
+        - Database specific:
+            * `datbase.name = 'orion'`
+            * `database.type = 'MongoDB'`
+            * `database.host = ${HOST}`
+
+2. Oríon specific environment variables:
+    Environment variables which can override global configuration
+    - Database specific:
+        * `ORION_DB_NAME`
+        * `ORION_DB_TYPE`
+        * `ORION_DB_ADDRESS`
+
+3. Experiment configuration inside the database
+    Configuration of the experiment if present in the database.
+    Making this part of the configuration of the experiment makes it possible
+    for the user to execute an experiment by only specifying partial configuration. The rest of the
+    configuration is fetched from the database.
+
+    For example, a user could:
+
+    1. Rerun the same experiment
+        Only providing the name is sufficient to rebuild the entire configuration of the
+        experiment.
+
+    2. Make a modification to an existing experiment
+        The user can provide the name of the existing experiment and only provide the changes to
+        apply on it. Here is an minimal example where we fully initialize a first experiment with a
+        config file and then branch from it with minimal information.
+
+        .. code-block:: bash
+
+            # Initialize root experiment
+            orion init_only --config previous_exeriment.yaml ./userscript -x~'uniform(0, 10)'
+            # Branch a new experiment
+            orion hunt -n previous_experiment ./userscript -x~'uniform(0, 100)'
+
+4. Configuration file
+    This configuration file is meant to overwrite the configuration coming from the database.
+    If this configuration file was interpreted as part of the global configuration, a user could
+    only modify an experiment using command line arguments.
+
+5. Command-line arguments
+    Those are the arguments provided to `orion` for any method (hunt, insert, etc). It includes the
+    argument to `orion` itself as well as the user's script name and its arguments.
+
+"""
+import datetime
+import getpass
+import logging
+import os
+
+import orion
+from orion.core.io import resolve_config
+from orion.core.io.database import Database, DuplicateKeyError
+from orion.core.worker.experiment import Experiment, ExperimentView
+
+
+log = logging.getLogger(__name__)
+
+
+class ExperimentBuilder(object):
+    """Builder for :class:`orion.core.worker.experiment.Experiment`
+    and :class:`orion.core.worker.experiment.ExperimentView`
+
+    .. seealso::
+
+        `orion.core.io.experiment_builder` for more information on the process of building
+        experiments.
+
+        :class:`orion.core.worker.experiment.Experiment`
+        :class:`orion.core.worker.experiment.ExperimentView`
+    """
+
+    # pylint:disable=no-self-use
+    def fetch_default_options(self):
+        """Get dictionary of default options"""
+        return resolve_config.fetch_default_options()
+
+    # pylint:disable=no-self-use
+    def fetch_env_vars(self):
+        """Get dictionary of environment variables specific to Oríon"""
+        return resolve_config.fetch_env_vars()
+
+    def fetch_file_config(self, cmdargs):
+        """Get dictionary of options from configuration file provided in command-line"""
+        return resolve_config.fetch_config(cmdargs)
+
+    def fetch_local_config(self, cmdargs):
+        """Get dictionary of options from all local sources (not from db)
+
+        .. seealso::
+
+            `orion.core.io.experiment_builder` for more information on the hierarchy of
+            configurations.
+        """
+        default_options = self.fetch_default_options()
+        env_vars = self.fetch_env_vars()
+        cmdconfig = self.fetch_file_config(cmdargs)
+
+        return resolve_config.merge_configs(default_options, env_vars, cmdconfig, cmdargs)
+
+    def fetch_db_config(self, cmdargs):
+        """Get dictionary of options from all local sources (not from db)
+
+        Note
+        ----
+            This method builds an experiment view in the background to fetch the configuration from
+            the database.
+        """
+        try:
+            experiment_view = self.build_view_from(cmdargs)
+        except ValueError as e:
+            if "No experiment with given name" in str(e):
+                return {}
+
+        return experiment_view.configuration
+
+    def fetch_full_config(self, cmdargs):
+        """Get dictionary of the full configuration of the experiment.
+
+        .. seealso::
+
+            `orion.core.io.experiment_builder` for more information on the hierarchy of
+            configurations.
+
+        Note
+        ----
+            This method builds an experiment view in the background to fetch the configuration from
+            the database.
+        """
+        default_options = self.fetch_default_options()
+        env_vars = self.fetch_env_vars()
+        db_config = self.fetch_db_config(cmdargs)
+        cmdconfig = self.fetch_file_config(cmdargs)
+
+        exp_config = resolve_config.merge_configs(
+            default_options, env_vars, db_config, cmdconfig, cmdargs)
+
+        # Infer rest information about the process + versioning
+        if 'metadata' not in exp_config:
+            exp_config['metadata'] = {}
+
+        exp_config['metadata']['orion_version'] = orion.core.__version__
+
+        # Move 'user_script' and 'user_args' to 'metadata' key
+        user_script = exp_config.pop('user_script', None)
+        if user_script:
+            abs_user_script = os.path.abspath(user_script)
+            if resolve_config.is_exe(abs_user_script):
+                user_script = abs_user_script
+
+        exp_config['metadata']['user_script'] = user_script
+        exp_config['metadata']['user_args'] = exp_config.pop('user_args', None)
+
+        exp_config['metadata']['user'] = getpass.getuser()
+
+        if 'datetime' not in exp_config['metadata']:
+            exp_config['metadata']['datetime'] = datetime.datetime.utcnow()
+
+        exp_config['metadata'] = resolve_config.infer_versioning_metadata(exp_config['metadata'])
+
+        return exp_config
+
+    def build_view_from(self, cmdargs):
+        """Build an experiment view based on full configuration.
+
+        .. seealso::
+
+            `orion.core.io.experiment_builder` for more information on the hierarchy of
+            configurations.
+
+            :class:`orion.core.worker.experiment.ExperimentView` for more information on the
+            experiment view object.
+        """
+        local_config = self.fetch_local_config(cmdargs)
+
+        db_opts = local_config['database']
+        dbtype = db_opts.pop('type')
+
+        # Information should be enough to infer experiment's name.
+        log.debug("Creating %s database client with args: %s", dbtype, db_opts)
+        try:
+            Database(of_type=dbtype, **db_opts)
+        except ValueError:
+            if Database().__class__.__name__.lower() != dbtype.lower():
+                raise
+
+        exp_name = local_config['name']
+        if exp_name is None:
+            raise RuntimeError("Could not infer experiment's name. "
+                               "Please use either `name` cmd line arg or provide "
+                               "one in orion's configuration file.")
+
+        return ExperimentView(local_config["name"])
+
+    def build_from(self, cmdargs):
+        """Build a fully configured (and writable) experiment based on full configuration.
+
+        .. seealso::
+
+            `orion.core.io.experiment_builder` for more information on the hierarchy of
+            configurations.
+
+            :class:`orion.core.worker.experiment.Experiment` for more information on the experiment
+            object.
+        """
+        full_config = self.fetch_full_config(cmdargs)
+
+        log.info(full_config)
+
+        # Pop out configuration concerning databases and resources
+        full_config.pop('database', None)
+        full_config.pop('resources', None)
+        full_config.pop('status', None)
+
+        return self.build_from_config(full_config)
+
+    def build_from_config(self, config):
+        """Build a fully configured (and writable) experiment based on full configuration.
+
+        .. seealso::
+
+            `orion.core.io.experiment_builder` for more information on the hierarchy of
+            configurations.
+
+            :class:`orion.core.worker.experiment.Experiment` for more information on the experiment
+            object.
+        """
+        log.info(config)
+
+        # Pop out configuration concerning databases and resources
+        config.pop('database', None)
+        config.pop('resources', None)
+        config.pop('status', None)
+
+        experiment = Experiment(config['name'])
+
+        # Finish experiment's configuration and write it to database.
+        try:
+            experiment.configure(config)
+        except DuplicateKeyError:
+            # Fails if concurrent experiment with identical (name, metadata.user)
+            # is written first in the database.
+            # Next build_from_config() should either load experiment from database
+            # and run smoothly if identical or trigger an experiment fork.
+            # In other words, there should not be more than 1 level of recursion.
+            experiment = self._build_from_config(config)
+
+        return experiment

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -17,61 +17,73 @@ straighforward. This is because there is many sources of configuration and they 
 hierarchy. From the more global to the more specific, there is:
 
 1. Global configuration:
-    Defined by `src.orion.core.io.resolve_config.DEF_CONFIG_FILES_PATHS`.
-    Can be scattered in user file system, defaults could look like:
-        - `/some/path/to/.virtualenvs/orion/share/orion.core`
-        - `/etc/xdg/xdg-ubuntu/orion.core`
-        - `/home/${USER}/.config/orion.core`
 
-    Note that some variables have default value even if user do not defined them in global
-    configuration:
-        - `max_trials = src.orion.core.io.resolve_config.DEF_CMD_MAX_TRIALS`
-        - `pool_size = src.orion.core.io.resolve_config.DEF_CMD_POOL_SIZE`
-        - `algorithms = random`
-        - Database specific:
-            * `database.name = 'orion'`
-            * `database.type = 'MongoDB'`
-            * `database.host = ${HOST}`
+  Defined by `src.orion.core.io.resolve_config.DEF_CONFIG_FILES_PATHS`.
+  Can be scattered in user file system, defaults could look like:
+
+    - `/some/path/to/.virtualenvs/orion/share/orion.core`
+    - `/etc/xdg/xdg-ubuntu/orion.core`
+    - `/home/${USER}/.config/orion.core`
+
+  Note that some variables have default value even if user do not defined them in global
+  configuration:
+
+    - `max_trials = src.orion.core.io.resolve_config.DEF_CMD_MAX_TRIALS`
+    - `pool_size = src.orion.core.io.resolve_config.DEF_CMD_POOL_SIZE`
+    - `algorithms = random`
+    - Database specific:
+
+      * `database.name = 'orion'`
+      * `database.type = 'MongoDB'`
+      * `database.host = ${HOST}`
 
 2. Oríon specific environment variables:
-    Environment variables which can override global configuration
+
+   Environment variables which can override global configuration
+
     - Database specific:
-        * `ORION_DB_NAME`
-        * `ORION_DB_TYPE`
-        * `ORION_DB_ADDRESS`
+
+      * `ORION_DB_NAME`
+      * `ORION_DB_TYPE`
+      * `ORION_DB_ADDRESS`
 
 3. Experiment configuration inside the database
-    Configuration of the experiment if present in the database.
-    Making this part of the configuration of the experiment makes it possible
-    for the user to execute an experiment by only specifying partial configuration. The rest of the
-    configuration is fetched from the database.
 
-    For example, a user could:
+  Configuration of the experiment if present in the database.
+  Making this part of the configuration of the experiment makes it possible
+  for the user to execute an experiment by only specifying partial configuration. The rest of the
+  configuration is fetched from the database.
+
+  For example, a user could:
 
     1. Rerun the same experiment
-        Only providing the name is sufficient to rebuild the entire configuration of the
-        experiment.
+
+      Only providing the name is sufficient to rebuild the entire configuration of the
+      experiment.
 
     2. Make a modification to an existing experiment
-        The user can provide the name of the existing experiment and only provide the changes to
-        apply on it. Here is an minimal example where we fully initialize a first experiment with a
-        config file and then branch from it with minimal information.
 
-        .. code-block:: bash
+      The user can provide the name of the existing experiment and only provide the changes to
+      apply on it. Here is an minimal example where we fully initialize a first experiment with a
+      config file and then branch from it with minimal information.
 
-            # Initialize root experiment
-            orion init_only --config previous_exeriment.yaml ./userscript -x~'uniform(0, 10)'
-            # Branch a new experiment
-            orion hunt -n previous_experiment ./userscript -x~'uniform(0, 100)'
+      .. code-block:: bash
+
+          # Initialize root experiment
+          orion init_only --config previous_exeriment.yaml ./userscript -x~'uniform(0, 10)'
+          # Branch a new experiment
+          orion hunt -n previous_experiment ./userscript -x~'uniform(0, 100)'
 
 4. Configuration file
-    This configuration file is meant to overwrite the configuration coming from the database.
-    If this configuration file was interpreted as part of the global configuration, a user could
-    only modify an experiment using command line arguments.
+
+  This configuration file is meant to overwrite the configuration coming from the database.
+  If this configuration file was interpreted as part of the global configuration, a user could
+  only modify an experiment using command line arguments.
 
 5. Command-line arguments
-    Those are the arguments provided to `orion` for any method (hunt, insert, etc). It includes the
-    argument to `orion` itself as well as the user's script name and its arguments.
+
+  Those are the arguments provided to `orion` for any method (hunt, insert, etc). It includes the
+  argument to `orion` itself as well as the user's script name and its arguments.
 
 """
 import logging

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -125,8 +125,8 @@ class ExperimentBuilder(object):
 
         return resolve_config.merge_configs(default_options, env_vars, cmdconfig, cmdargs)
 
-    def fetch_db_config(self, cmdargs):
-        """Get dictionary of options from all local sources (not from db)
+    def fetch_config_from_db(self, cmdargs):
+        """Get dictionary of options from experiment found in the database
 
         Note
         ----
@@ -161,12 +161,12 @@ class ExperimentBuilder(object):
         """
         default_options = self.fetch_default_options()
         env_vars = self.fetch_env_vars()
-        db_config = self.fetch_db_config(cmdargs)
+        config_from_db = self.fetch_config_from_db(cmdargs)
         cmdconfig = self.fetch_file_config(cmdargs)
         metadata = dict(metadata=self.fetch_metadata(cmdargs))
 
         exp_config = resolve_config.merge_configs(
-            default_options, env_vars, db_config, cmdconfig, cmdargs, metadata)
+            default_options, env_vars, config_from_db, cmdconfig, cmdargs, metadata)
 
         return exp_config
 

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -184,9 +184,6 @@ class ExperimentBuilder(object):
 
         exp_config['metadata']['user'] = getpass.getuser()
 
-        if 'datetime' not in exp_config['metadata']:
-            exp_config['metadata']['datetime'] = datetime.datetime.utcnow()
-
         exp_config['metadata'] = resolve_config.infer_versioning_metadata(exp_config['metadata'])
 
         return exp_config

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -74,12 +74,8 @@ hierarchy. From the more global to the more specific, there is:
     argument to `orion` itself as well as the user's script name and its arguments.
 
 """
-import datetime
-import getpass
 import logging
-import os
 
-import orion
 from orion.core.io import resolve_config
 from orion.core.io.database import Database, DuplicateKeyError
 from orion.core.worker.experiment import Experiment, ExperimentView
@@ -145,6 +141,10 @@ class ExperimentBuilder(object):
 
         return experiment_view.configuration
 
+    def fetch_metadata(self, cmdargs):
+        """Infer rest information about the process + versioning"""
+        return resolve_config.fetch_metadata(cmdargs)
+
     def fetch_full_config(self, cmdargs):
         """Get dictionary of the full configuration of the experiment.
 
@@ -157,34 +157,16 @@ class ExperimentBuilder(object):
         ----
             This method builds an experiment view in the background to fetch the configuration from
             the database.
+
         """
         default_options = self.fetch_default_options()
         env_vars = self.fetch_env_vars()
         db_config = self.fetch_db_config(cmdargs)
         cmdconfig = self.fetch_file_config(cmdargs)
+        metadata = dict(metadata=self.fetch_metadata(cmdargs))
 
         exp_config = resolve_config.merge_configs(
-            default_options, env_vars, db_config, cmdconfig, cmdargs)
-
-        # Infer rest information about the process + versioning
-        if 'metadata' not in exp_config:
-            exp_config['metadata'] = {}
-
-        exp_config['metadata']['orion_version'] = orion.core.__version__
-
-        # Move 'user_script' and 'user_args' to 'metadata' key
-        user_script = exp_config.pop('user_script', None)
-        if user_script:
-            abs_user_script = os.path.abspath(user_script)
-            if resolve_config.is_exe(abs_user_script):
-                user_script = abs_user_script
-
-        exp_config['metadata']['user_script'] = user_script
-        exp_config['metadata']['user_args'] = exp_config.pop('user_args', None)
-
-        exp_config['metadata']['user'] = getpass.getuser()
-
-        exp_config['metadata'] = resolve_config.infer_versioning_metadata(exp_config['metadata'])
+            default_options, env_vars, db_config, cmdconfig, cmdargs, metadata)
 
         return exp_config
 

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -244,6 +244,6 @@ class ExperimentBuilder(object):
             # Next build_from_config() should either load experiment from database
             # and run smoothly if identical or trigger an experiment fork.
             # In other words, there should not be more than 1 level of recursion.
-            experiment = self._build_from_config(config)
+            experiment = self.build_from_config(config)
 
         return experiment

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -29,7 +29,7 @@ hierarchy. From the more global to the more specific, there is:
         - `pool_size = src.orion.core.io.resolve_config.DEF_CMD_POOL_SIZE`
         - `algorithms = random`
         - Database specific:
-            * `datbase.name = 'orion'`
+            * `database.name = 'orion'`
             * `database.type = 'MongoDB'`
             * `database.host = ${HOST}`
 

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -81,10 +81,11 @@ ENV_VARS = dict(
 
 def fetch_config(args):
     """Return the config inside the .yaml file if present."""
-    orion_file = args.pop('config')
+    orion_file = args.get('config')
     config = dict()
     if orion_file:
         log.debug("Found orion configuration file at: %s", os.path.abspath(orion_file.name))
+        orion_file.seek(0)
         config = yaml.safe_load(orion_file)
 
     return config

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -31,6 +31,7 @@ precedence is respected when building the settings dictionary:
 .. note:: `Optimization` entries are required, `Dynamic` entry is optional.
 
 """
+import getpass
 import logging
 import os
 import socket
@@ -153,6 +154,27 @@ def fetch_env_vars():
                 env_vars[signif][key] = value
 
     return env_vars
+
+
+def fetch_metadata(cmdargs):
+    """Infer rest information about the process + versioning"""
+    metadata = {}
+
+    metadata['orion_version'] = orion.core.__version__
+
+    # Move 'user_script' and 'user_args' to 'metadata' key
+    user_script = cmdargs.get('user_script', None)
+    if user_script:
+        abs_user_script = os.path.abspath(user_script)
+        if is_exe(abs_user_script):
+            user_script = abs_user_script
+
+    metadata['user_script'] = user_script
+    metadata['user_args'] = cmdargs.get('user_args', None)
+
+    metadata['user'] = getpass.getuser()
+
+    return infer_versioning_metadata(metadata)
 
 
 def merge_configs(*configs):

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -139,14 +139,6 @@ def fetch_default_options():
     return default_config
 
 
-def merge_env_vars(config):
-    """Fetch environmental variables related to orion's managerial data.
-
-    :type config: :func:`nesteddict`
-    """
-    return merge_configs(config, fetch_env_vars())
-
-
 def fetch_env_vars():
     """Fetch environmental variables related to orion's managerial data."""
     env_vars = {}
@@ -161,39 +153,6 @@ def fetch_env_vars():
                 env_vars[signif][key] = value
 
     return env_vars
-
-
-def merge_orion_config(config, dbconfig, cmdconfig, cmdargs):
-    """
-    Oríon Configuration
-    -------------------
-
-    name --  Experiment's name.
-
-       If you provide a past experiment's name,
-       then that experiment will be resumed. This means that its history of
-       trials will be reused, along with any configurations logged in the
-       database which are not overwritten by current call to `orion` script.
-
-    max_trials -- Maximum number of trial evaluations to be computed
-
-       (required as a cmd line argument or a orion_config parameter)
-
-    pool_size -- Number of workers evaluating in parallel asychronously
-
-       (default: 10 @ default resource). Can be a dict of the form:
-       {resource_alias: subpool_size}
-
-    database -- dict with keys: 'type', 'name', 'host', 'port', 'username', 'password'
-
-    resources -- {resource_alias: (entry_address, scheduler, scheduler_ops)} (optional)
-
-    algorithm -- {optimizer module name : method-specific configuration}
-
-    .. seealso:: Method-specific configurations reside in `/config`
-
-    """
-    return merge_configs(config, dbconfig, cmdconfig, cmdargs)
 
 
 def merge_configs(*configs):

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -31,13 +31,9 @@ precedence is respected when building the settings dictionary:
 .. note:: `Optimization` entries are required, `Dynamic` entry is optional.
 
 """
-import argparse
-from collections import defaultdict
-from copy import deepcopy
 import logging
 import os
 import socket
-import textwrap
 
 from numpy import inf as infinity
 import yaml
@@ -87,54 +83,6 @@ ENV_VARS_DB = [
 ENV_VARS = dict(
     database=ENV_VARS_DB
     )
-################################################################################
-#                           Input Parsing Functions                            #
-################################################################################
-
-
-class OrionArgsParser:
-    """Parser object handling the upper-level parsing of Oríon's arguments."""
-
-    def __init__(self, description):
-        """Create the pre-command arguments"""
-        self.description = description
-
-        self.parser = argparse.ArgumentParser(
-            formatter_class=argparse.RawDescriptionHelpFormatter,
-            description=textwrap.dedent(description))
-
-        self.parser.add_argument(
-            '-V', '--version',
-            action='version', version='orion ' + orion.core.__version__)
-
-        self.parser.add_argument(
-            '-v', '--verbose',
-            action='count', default=0,
-            help="logging levels of information about the process (-v: INFO. -vv: DEBUG)")
-
-        self.subparsers = self.parser.add_subparsers(help='sub-command help')
-
-    def get_subparsers(self):
-        """Return the subparser object for this parser."""
-        return self.subparsers
-
-    def parse(self, argv):
-        """Call argparse and generate a dictionary of arguments' value"""
-        args = vars(self.parser.parse_args(argv))
-
-        verbose = args.pop('verbose', 0)
-        if verbose == 1:
-            logging.basicConfig(level=logging.INFO)
-        elif verbose == 2:
-            logging.basicConfig(level=logging.DEBUG)
-
-        function = args.pop('func')
-        return args, function
-
-    def execute(self, argv):
-        """Execute main function of the subparser"""
-        args, function = self.parse(argv)
-        function(args)
 
 
 def fetch_config(args):
@@ -146,49 +94,6 @@ def fetch_config(args):
         config = yaml.safe_load(orion_file)
 
     return config
-
-
-def get_basic_args_group(parser):
-    """Return the basic arguments for any command."""
-    basic_args_group = parser.add_argument_group(
-        "Oríon arguments (optional)",
-        description="These arguments determine orion's behaviour")
-
-    basic_args_group.add_argument(
-        '-n', '--name',
-        type=str, metavar='stringID',
-        help="experiment's unique name; "
-             "(default: None - specified either here or in a config)")
-
-    basic_args_group.add_argument('-c', '--config', type=argparse.FileType('r'),
-                                  metavar='path-to-config', help="user provided "
-                                  "orion configuration file")
-
-    return basic_args_group
-
-
-def get_user_args_group(parser):
-    """
-    Return the user group arguments for any command.
-    User group arguments are composed of the user script and the user args
-    """
-    usergroup = parser.add_argument_group(
-        "User script related arguments",
-        description="These arguments determine user's script behaviour "
-                    "and they can serve as orion's parameter declaration.")
-
-    usergroup.add_argument(
-        'user_script', type=str, metavar='path-to-script',
-        help="your experiment's script")
-
-    usergroup.add_argument(
-        'user_args', nargs=argparse.REMAINDER, metavar='...',
-        help="Command line arguments to your script (if any). A configuration "
-             "file intended to be used with 'userscript' must be given as a path "
-             "in the **first positional** argument OR using `--config=<path>` "
-             "keyword argument.")
-
-    return usergroup
 
 
 def fetch_default_options():
@@ -252,6 +157,10 @@ def merge_env_vars(config):
     return newcfg
 
 
+def merge_configs(*configs):
+    raise NotImplementedError
+
+
 def merge_orion_config(config, dbconfig, cmdconfig, cmdargs):
     """
     Oríon Configuration
@@ -301,3 +210,11 @@ def merge_orion_config(config, dbconfig, cmdconfig, cmdargs):
                 expconfig[k] = v
 
     return expconfig
+
+
+def infer_versioning_metadata(existing_metadata):
+    """Infer information about user's script versioning if available."""
+    # VCS system
+    # User repo's version
+    # User repo's HEAD commit hash
+    return existing_metadata

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -41,12 +41,6 @@ import yaml
 import orion
 
 
-# Define type of arbitrary nested defaultdicts
-def nesteddict():
-    """Extend defaultdict to arbitrary nested levels."""
-    return defaultdict(nesteddict)
-
-
 def is_exe(path):
     """Test whether `path` describes an executable file."""
     return os.path.isfile(path) and os.access(path, os.X_OK)
@@ -97,7 +91,7 @@ def fetch_config(args):
 
 
 def fetch_default_options():
-    """Create a nesteddict with options from the default configuration files.
+    """Create a dict with options from the default configuration files.
 
     Respect precedence from application's default, to system's and
     user's.
@@ -105,7 +99,7 @@ def fetch_default_options():
     .. seealso:: :const:`DEF_CONFIG_FILES_PATHS`
 
     """
-    default_config = nesteddict()
+    default_config = dict()
 
     # get some defaults
     default_config['name'] = None
@@ -115,6 +109,7 @@ def fetch_default_options():
 
     # get default options for some managerial variables (see :const:`ENV_VARS`)
     for signifier, env_vars in ENV_VARS.items():
+        default_config[signifier] = {}
         for _, key, default_value in env_vars:
             default_config[signifier][key] = default_value
 
@@ -128,6 +123,7 @@ def fetch_default_options():
                 # implies that yaml must be in dict form
                 for k, v in cfg.items():
                     if k in ENV_VARS:
+                        default_config[k] = {}
                         for vk, vv in v.items():
                             default_config[k][vk] = vv
                     else:
@@ -146,19 +142,24 @@ def merge_env_vars(config):
     """Fetch environmental variables related to orion's managerial data.
 
     :type config: :func:`nesteddict`
-
     """
-    newcfg = deepcopy(config)
+    return merge_configs(config, fetch_env_vars())
+
+
+def fetch_env_vars():
+    """Fetch environmental variables related to orion's managerial data."""
+    env_vars = {}
+
     for signif, evars in ENV_VARS.items():
+        env_vars[signif] = {}
+
         for var_name, key, _ in evars:
             value = os.getenv(var_name)
+
             if value is not None:
-                newcfg[signif][key] = value
-    return newcfg
+                env_vars[signif][key] = value
 
-
-def merge_configs(*configs):
-    raise NotImplementedError
+    return env_vars
 
 
 def merge_orion_config(config, dbconfig, cmdconfig, cmdargs):
@@ -191,25 +192,61 @@ def merge_orion_config(config, dbconfig, cmdconfig, cmdargs):
     .. seealso:: Method-specific configurations reside in `/config`
 
     """
-    expconfig = deepcopy(config)
+    return merge_configs(config, dbconfig, cmdconfig, cmdargs)
 
-    for cfg in (dbconfig, cmdconfig):
-        for k, v in cfg.items():
-            if k in ENV_VARS:
-                for vk, vv in v.items():
-                    expconfig[k][vk] = vv
-            elif v is not None:
-                expconfig[k] = v
 
-    for k, v in cmdargs.items():
-        if v is not None:
-            if k == 'metadata':
-                for vk, vv in v.items():
-                    expconfig[k][vk] = vv
-            else:
-                expconfig[k] = v
+def merge_configs(*configs):
+    """Merge configuration dictionnaries following the given hierarchy
 
-    return expconfig
+    Suppose function is called as merge_configs(A, B, C). Then any pair (key, value) in C would
+    overwrite any previous value from A or B. Same apply for B over A.
+
+    If for some pair (key, value), the value is a dictionary, then it will either overwrite previous
+    value if it was not also a directory, or it will be merged following
+    `merge_configs(old_value, new_value)`.
+
+    .. warning:
+
+        Redefinition of subdictionaries may lead to confusing results because merges do not remove
+        data.
+
+        If for instance, we have {'a': {'b': 1, 'c': 2}} and we would like to update `'a'` such that
+        it only have `{'c': 3}`, it won't work with {'a': {'c': 3}}.
+
+        merge_configs({'a': {'b': 1, 'c': 2}}, {'a': {'c': 3}}) -> {'a': {'b': 1, 'c': 3}}
+
+    Example
+    -------
+    .. code-block:: python
+        :linenos:
+
+        a = {'a': 1, 'b': {'c': 2}}
+        b = {'b': {'c': 3}}
+        c = {'b': {'c': {'d': 4}}}
+
+        m = resolve_config.merge_configs(a, b, c)
+
+        assert m == {'a': 1, 'b': {'c': {'d': 4}}}
+
+        a = {'a': 1, 'b': {'c': 2, 'd': 3}}
+        b = {'b': {'c': 4}}
+        c = {'b': {'c': {'e': 5}}}
+
+        m = resolve_config.merge_configs(a, b, c)
+
+        assert m == {'a': 1, 'b': {'c': {'e': 5}, 'd': 3}}
+
+    """
+    merged_config = configs[0]
+
+    for config in configs[1:]:
+        for key, value in config.items():
+            if isinstance(value, dict) and isinstance(merged_config.get(key), dict):
+                merged_config[key] = merge_configs(merged_config[key], value)
+            elif value is not None:
+                merged_config[key] = value
+
+    return merged_config
 
 
 def infer_versioning_metadata(existing_metadata):

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -316,8 +316,7 @@ class Experiment(object):
         # orion_config to set.
         if self._id is None:
             if config['name'] != self.name or \
-                    config['metadata']['user'] != self.metadata['user'] or \
-                    config['metadata']['datetime'] != self.metadata['datetime']:
+                    config['metadata']['user'] != self.metadata['user']:
                 raise ValueError("Configuration given is inconsistent with this Experiment.")
             is_new = True
         else:

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -305,6 +305,11 @@ class Experiment(object):
         if self._init_done:
             raise RuntimeError("Configuration is done; cannot reset an Experiment.")
 
+        # Experiment was build using db, but config was build before experiment got in db.
+        # Fake a DuplicateKeyError to force reinstantiation of experiment with proper config.
+        if self._id is not None and "datetime" not in config['metadata']:
+            raise DuplicateKeyError("Cannot register an existing experiment with a new config")
+
         # Copy and simulate instantiating given configuration
         experiment = Experiment(self.name)
         experiment._instantiate_config(self.configuration)

--- a/src/orion/core/worker/experiment.py
+++ b/src/orion/core/worker/experiment.py
@@ -101,8 +101,7 @@ class Experiment(object):
         self.name = name
         self.refers = None
         user = getpass.getuser()
-        stamp = datetime.datetime.utcnow()
-        self.metadata = {'user': user, 'datetime': stamp}
+        self.metadata = {'user': user}
         self.pool_size = None
         self.max_trials = None
         self.algorithms = None
@@ -123,13 +122,14 @@ class Experiment(object):
                     setattr(self, attrname, config[attrname])
             self._id = config['_id']
 
-        self._last_fetched = self.metadata['datetime']
+        self._last_fetched = self.metadata.get("datetime", datetime.datetime.utcnow())
 
     def _setup_db(self):
         self._db.ensure_index('experiments',
                               [('name', Database.ASCENDING),
                                ('metadata.user', Database.ASCENDING)],
                               unique=True)
+        self._db.ensure_index('experiments', 'metadata.datetime')
 
         self._db.ensure_index('trials', 'experiment')
         self._db.ensure_index('trials', 'status')
@@ -332,6 +332,7 @@ class Experiment(object):
 
         # If everything is alright, push new config to database
         if is_new:
+            final_config['metadata']['datetime'] = datetime.datetime.utcnow()
             # This will raise DuplicateKeyError if a concurrent experiment with
             # identical (name, metadata.user) is written first in the database.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 
 from orion.algo.base import (BaseAlgorithm, OptimizationAlgorithm)
+from orion.core.io import resolve_config
 from orion.core.io.database import Database
 from orion.core.io.database.mongodb import MongoDB
 from orion.core.worker.trial import Trial
@@ -129,3 +130,15 @@ def null_db_instances():
     """Nullify singleton instance so that we can assure independent instantiation tests."""
     Database.instance = None
     MongoDB.instance = None
+
+
+@pytest.fixture
+def version_XYZ(monkeypatch):
+    """Force orion version XYZ on output of resolve_config.fetch_metadata"""
+    non_patched_fetch_metadata = resolve_config.fetch_metadata
+
+    def fetch_metadata(cmdargs):
+        metadata = non_patched_fetch_metadata(cmdargs)
+        metadata['orion_version'] = 'XYZ'
+        return metadata
+    monkeypatch.setattr(resolve_config, "fetch_metadata", fetch_metadata)

--- a/tests/functional/parsing/test_parsing_base.py
+++ b/tests/functional/parsing/test_parsing_base.py
@@ -6,7 +6,7 @@ import os
 
 import pytest
 
-from orion.core.cli import resolve_config
+import orion.core.cli.base as cli
 
 
 def _create_parser(need_subparser=True):
@@ -26,7 +26,7 @@ def test_common_group_arguments(database, monkeypatch):
     parser, subparsers = _create_parser()
     args_list = ["-n", "test", "--config", "./orion_config_random.yaml"]
 
-    resolve_config.get_basic_args_group(parser)
+    cli.get_basic_args_group(parser)
     args = vars(parser.parse_args(args_list))
     assert args['name'] == 'test'
     assert args['config'].name == "./orion_config_random.yaml"
@@ -39,7 +39,7 @@ def test_user_group_arguments(database, monkeypatch):
     parser = _create_parser(False)
     args_list = ["./black_box.py", "-x~normal(50,50)"]
 
-    resolve_config.get_user_args_group(parser)
+    cli.get_user_args_group(parser)
     args = vars(parser.parse_args(args_list))
     assert args['user_script'] == './black_box.py'
     assert len(args['user_args']) == 1
@@ -54,8 +54,8 @@ def test_common_and_user_group_arguments(database, monkeypatch):
     args_list = ["-n", "test", "-c", "./orion_config_random.yaml",
                  "./black_box.py", "-x~normal(50,50)"]
 
-    resolve_config.get_basic_args_group(parser)
-    resolve_config.get_user_args_group(parser)
+    cli.get_basic_args_group(parser)
+    cli.get_user_args_group(parser)
     args = vars(parser.parse_args(args_list))
     assert args['name'] == 'test'
     assert args['config'].name == './orion_config_random.yaml'

--- a/tests/unittests/core/experiment.yaml
+++ b/tests/unittests/core/experiment.yaml
@@ -96,7 +96,6 @@
         value: gru
   pool_size: 2
   max_trials: 1
-  status: done
   algorithms:
     dumbalgo:  # this must be logged as `Experiment` would log it, complete specification
       value: 5

--- a/tests/unittests/core/experiment.yaml
+++ b/tests/unittests/core/experiment.yaml
@@ -12,7 +12,7 @@
     user: tsirif
     datetime: 2017-11-22T20:00:00
     # from orion.__version__
-    orion_version: 0.1
+    orion_version: XYZ
     # from `orion`'s args
     user_script: full_path/main.py
     # from `orion`'s args
@@ -53,7 +53,7 @@
   metadata:
     user: tsirif
     datetime: 2017-11-22T21:00:00
-    orion_version: 0.1
+    orion_version: XYZ
     user_script: full_path/ieeeela.py
     user_args: ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])", "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"]
     user_vcs: git
@@ -81,7 +81,7 @@
   metadata:
     user: tsirif
     datetime: 2017-11-22T21:00:00
-    orion_version: 0.1
+    orion_version: XYZ
     user_script: full_path/ieeeela.py
     user_args: ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])", "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"]
     user_vcs: git
@@ -109,7 +109,7 @@
   metadata:
     user: dendi
     datetime: 2017-11-22T20:00:00
-    orion_version: 0.1
+    orion_version: XYZ
     user_script: full_path/main.py
     user_args: ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])", "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"]
     user_vcs: git

--- a/tests/unittests/core/io/conftest.py
+++ b/tests/unittests/core/io/conftest.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Common fixtures and utils for io tests."""
+
+
+import os
+
+import pytest
+
+
+@pytest.fixture()
+def config_file():
+    """Open config file with new config"""
+    file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                             "orion_config.yaml")
+
+    return open(file_path)

--- a/tests/unittests/core/io/conftest.py
+++ b/tests/unittests/core/io/conftest.py
@@ -15,3 +15,21 @@ def config_file():
                              "orion_config.yaml")
 
     return open(file_path)
+
+
+@pytest.fixture()
+def old_config_file():
+    """Open config file with original config from an experiment in db"""
+    file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                             "orion_old_config.yaml")
+
+    return open(file_path)
+
+
+@pytest.fixture()
+def incomplete_config_file():
+    """Open config file with partial database configuration"""
+    file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                             "orion_incomplete_config.yaml")
+
+    return open(file_path)

--- a/tests/unittests/core/io/orion_config.yaml
+++ b/tests/unittests/core/io/orion_config.yaml
@@ -1,0 +1,11 @@
+name: voila_voici
+
+pool_size: 1
+max_trials: 100
+
+algorithms: 'random'
+
+database:
+  type: 'mongodb'
+  name: 'orion_test'
+  host: 'mongodb://user:pass@localhost'

--- a/tests/unittests/core/io/orion_incomplete_config.yaml
+++ b/tests/unittests/core/io/orion_incomplete_config.yaml
@@ -1,0 +1,5 @@
+name: incomplete
+
+database:
+  type: 'incomplete'
+  host: 'mongodb://user:pass@localhost'

--- a/tests/unittests/core/io/orion_old_config.yaml
+++ b/tests/unittests/core/io/orion_old_config.yaml
@@ -1,0 +1,17 @@
+name: voila_voici
+
+pool_size: 2
+max_trials: 1000
+
+algorithms:
+    dumbalgo:
+        done: False
+        judgement: null
+        scoring: 0
+        suspend: False
+        value: 5
+
+database:
+  type: 'mongodb'
+  name: 'orion_test'
+  host: 'mongodb://user:pass@localhost'

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -97,9 +97,6 @@ def test_fetch_full_config_new_config(config_file, exp_config, random_dt):
 
     assert full_config['name'] == exp_config[0][0]['name']
     assert full_config['refers'] == exp_config[0][0]['refers']
-    assert full_config['metadata']['datetime'] == exp_config[0][0]['metadata']['datetime']
-    assert full_config['metadata'] == exp_config[0][0]['metadata']
-    assert full_config['metadata'] == exp_config[0][0]['metadata']
     assert full_config['metadata'] == exp_config[0][0]['metadata']
     assert full_config['pool_size'] == cmdconfig['pool_size']
     assert full_config['max_trials'] == cmdconfig['max_trials']
@@ -143,8 +140,8 @@ def test_fetch_full_config_no_hit(config_file, exp_config, random_dt):
     assert full_config['max_trials'] == 100
     assert full_config['name'] == 'supernaekei'
     assert full_config['pool_size'] == 1
-    assert full_config['metadata']['datetime'] == random_dt
     assert full_config['metadata']['user'] == 'tsirif'
+    assert 'datetime' not in full_config['metadata']
     assert 'refers' not in full_config
     assert 'status' not in full_config
 

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -42,18 +42,18 @@ def test_fetch_local_config_from_incomplete_config(incomplete_config_file):
 
 
 @pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
-def test_fetch_db_config_no_hit(config_file, random_dt):
-    """Verify that fetch_db_config returns an empty dict when the experiment is not in db"""
+def test_fetch_config_from_db_no_hit(config_file, random_dt):
+    """Verify that fetch_config_from_db returns an empty dict when the experiment is not in db"""
     cmdargs = {'name': 'supernaekei', 'config': config_file}
-    db_config = ExperimentBuilder().fetch_db_config(cmdargs)
+    db_config = ExperimentBuilder().fetch_config_from_db(cmdargs)
     assert db_config == {}
 
 
 @pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
-def test_fetch_db_config_hit(config_file, exp_config):
+def test_fetch_config_from_db_hit(config_file, exp_config, random_dt):
     """Verify db config when experiment is in db"""
     cmdargs = {'name': 'supernaedo2', 'config': config_file}
-    db_config = ExperimentBuilder().fetch_db_config(cmdargs)
+    db_config = ExperimentBuilder().fetch_config_from_db(cmdargs)
 
     assert db_config['name'] == exp_config[0][0]['name']
     assert db_config['refers'] == exp_config[0][0]['refers']

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -60,7 +60,6 @@ def test_fetch_config_from_db_hit(config_file, exp_config, random_dt):
     assert db_config['metadata'] == exp_config[0][0]['metadata']
     assert db_config['pool_size'] == exp_config[0][0]['pool_size']
     assert db_config['max_trials'] == exp_config[0][0]['max_trials']
-    assert db_config['status'] == exp_config[0][0]['status']
     assert db_config['algorithms'] == exp_config[0][0]['algorithms']
 
 
@@ -121,7 +120,6 @@ def test_fetch_full_config_no_hit(config_file, exp_config, random_dt):
     assert full_config['metadata']['user'] == 'tsirif'
     assert 'datetime' not in full_config['metadata']
     assert 'refers' not in full_config
-    assert 'status' not in full_config
 
 
 @pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
@@ -149,7 +147,6 @@ def test_build_view_from(config_file, create_db_instance, exp_config, random_dt)
     assert exp_view._experiment._last_fetched == exp_config[0][0]['metadata']['datetime']
     assert exp_view.pool_size == exp_config[0][0]['pool_size']
     assert exp_view.max_trials == exp_config[0][0]['max_trials']
-    assert exp_view.status == exp_config[0][0]['status']
     assert exp_view.algorithms.configuration == exp_config[0][0]['algorithms']
 
 
@@ -175,7 +172,6 @@ def test_build_from_no_hit(config_file, create_db_instance, exp_config, random_d
     assert exp._last_fetched == random_dt
     assert exp.pool_size == 1
     assert exp.max_trials == 100
-    assert exp.status == 'pending'
     assert exp.algorithms.configuration == {'random': {}}
 
 
@@ -201,7 +197,6 @@ def test_build_from_hit(old_config_file, create_db_instance, exp_config):
     assert exp._last_fetched == exp_config[0][0]['metadata']['datetime']
     assert exp.pool_size == exp_config[0][0]['pool_size']
     assert exp.max_trials == exp_config[0][0]['max_trials']
-    assert exp.status == exp_config[0][0]['status']
     assert exp.algorithms.configuration == exp_config[0][0]['algorithms']
 
 
@@ -228,7 +223,7 @@ def test_build_from_config_no_hit(config_file, create_db_instance, exp_config, r
     assert exp._last_fetched == random_dt
     assert exp.pool_size == 1
     assert exp.max_trials == 100
-    assert exp.status == 'pending'
+    assert not exp.is_done
     assert exp.algorithms.configuration == {'random': {}}
 
 
@@ -256,5 +251,4 @@ def test_build_from_config_hit(old_config_file, create_db_instance, exp_config):
     assert exp._last_fetched == exp_config[0][0]['metadata']['datetime']
     assert exp.pool_size == exp_config[0][0]['pool_size']
     assert exp.max_trials == exp_config[0][0]['max_trials']
-    assert exp.status == exp_config[0][0]['status']
     assert exp.algorithms.configuration == exp_config[0][0]['algorithms']

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -7,18 +7,6 @@ import pytest
 from orion.core.io.experiment_builder import ExperimentBuilder
 
 
-@pytest.fixture
-def version_01(monkeypatch):
-    """Force orion version 0.1 on output of ExperimentBuilder.fetch_full_config"""
-    non_patched_fetch_full_config = ExperimentBuilder.fetch_full_config
-
-    def fetch_full_config(self, cmdargs):
-        full_config = non_patched_fetch_full_config(self, cmdargs)
-        full_config['metadata']['orion_version'] = 0.1
-        return full_config
-    monkeypatch.setattr(ExperimentBuilder, "fetch_full_config", fetch_full_config)
-
-
 @pytest.mark.usefixtures("clean_db")
 def test_fetch_local_config(config_file):
     """Test local config (default, env_vars, cmdconfig, cmdargs)"""
@@ -53,9 +41,7 @@ def test_fetch_local_config_from_incomplete_config(incomplete_config_file):
     assert local_config['pool_size'] == 10
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
 def test_fetch_db_config_no_hit(config_file, random_dt):
     """Verify that fetch_db_config returns an empty dict when the experiment is not in db"""
     cmdargs = {'name': 'supernaekei', 'config': config_file}
@@ -63,9 +49,7 @@ def test_fetch_db_config_no_hit(config_file, random_dt):
     assert db_config == {}
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
 def test_fetch_db_config_hit(config_file, exp_config):
     """Verify db config when experiment is in db"""
     cmdargs = {'name': 'supernaedo2', 'config': config_file}
@@ -80,9 +64,7 @@ def test_fetch_db_config_hit(config_file, exp_config):
     assert db_config['algorithms'] == exp_config[0][0]['algorithms']
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
 def test_fetch_full_config_new_config(config_file, exp_config, random_dt):
     """Verify full config with new config (causing branch)"""
     cmdargs = {'name': 'supernaedo2',
@@ -103,10 +85,8 @@ def test_fetch_full_config_new_config(config_file, exp_config, random_dt):
     assert full_config['algorithms'] == cmdconfig['algorithms']
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
-def test_fetch_full_config_old_config(old_config_file, exp_config):
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
+def test_fetch_full_config_old_config(old_config_file, exp_config, random_dt):
     """Verify full config with old config (not causing branch)"""
     cmdargs = {'name': 'supernaedo2',
                'config': old_config_file,
@@ -127,9 +107,7 @@ def test_fetch_full_config_old_config(old_config_file, exp_config):
     assert full_config['algorithms'] == cmdconfig['algorithms']
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
 def test_fetch_full_config_no_hit(config_file, exp_config, random_dt):
     """Verify full config when experiment not in db"""
     cmdargs = {'name': 'supernaekei', 'config': config_file}
@@ -146,9 +124,7 @@ def test_fetch_full_config_no_hit(config_file, exp_config, random_dt):
     assert 'status' not in full_config
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
 def test_build_view_from_no_hit(config_file, create_db_instance, exp_config):
     """Try building experiment view when not in db"""
     cmdargs = {'name': 'supernaekei', 'config': config_file}
@@ -158,10 +134,8 @@ def test_build_view_from_no_hit(config_file, create_db_instance, exp_config):
     assert "No experiment with given name 'supernaekei' for user 'tsirif'" in str(exc_info.value)
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
-def test_build_view_from(config_file, create_db_instance, exp_config):
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
+def test_build_view_from(config_file, create_db_instance, exp_config, random_dt):
     """Try building experiment view when in db"""
     cmdargs = {'name': 'supernaedo2', 'config': config_file}
     exp_view = ExperimentBuilder().build_view_from(cmdargs)
@@ -179,9 +153,7 @@ def test_build_view_from(config_file, create_db_instance, exp_config):
     assert exp_view.algorithms.configuration == exp_config[0][0]['algorithms']
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
 def test_build_from_no_hit(config_file, create_db_instance, exp_config, random_dt):
     """Try building experiment when not in db"""
     cmdargs = {'name': 'supernaekei', 'config': config_file,
@@ -207,10 +179,7 @@ def test_build_from_no_hit(config_file, create_db_instance, exp_config, random_d
     assert exp.algorithms.configuration == {'random': {}}
 
 
-@pytest.mark.usefixtures("version_01")
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("version_XYZ", "clean_db", "null_db_instances", "with_user_tsirif")
 def test_build_from_hit(old_config_file, create_db_instance, exp_config):
     """Try building experiment when in db (no branch)"""
     cmdargs = {'name': 'supernaedo2',
@@ -236,10 +205,7 @@ def test_build_from_hit(old_config_file, create_db_instance, exp_config):
     assert exp.algorithms.configuration == exp_config[0][0]['algorithms']
 
 
-@pytest.mark.usefixtures("version_01")
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("version_XYZ", "clean_db", "null_db_instances", "with_user_tsirif")
 def test_build_from_config_no_hit(config_file, create_db_instance, exp_config, random_dt):
     """Try building experiment from config when not in db"""
     cmdargs = {'name': 'supernaekei', 'config': config_file,
@@ -266,9 +232,7 @@ def test_build_from_config_no_hit(config_file, create_db_instance, exp_config, r
     assert exp.algorithms.configuration == {'random': {}}
 
 
-@pytest.mark.usefixtures("clean_db")
-@pytest.mark.usefixtures("null_db_instances")
-@pytest.mark.usefixtures("with_user_tsirif")
+@pytest.mark.usefixtures("clean_db", "null_db_instances", "with_user_tsirif")
 def test_build_from_config_hit(old_config_file, create_db_instance, exp_config):
     """Try building experiment from config when in db (no branch)"""
     cmdargs = {'name': 'supernaedo2',

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Example usage and tests for :mod:`orion.core.io.experiment_builder`."""
+
+import pytest
+
+from orion.core.io.experiment_builder import ExperimentBuilder
+
+
+@pytest.fixture
+def version_01(monkeypatch):
+    """Force orion version 0.1 on output of ExperimentBuilder.fetch_full_config"""
+    non_patched_fetch_full_config = ExperimentBuilder.fetch_full_config
+
+    def fetch_full_config(self, cmdargs):
+        full_config = non_patched_fetch_full_config(self, cmdargs)
+        full_config['metadata']['orion_version'] = 0.1
+        return full_config
+    monkeypatch.setattr(ExperimentBuilder, "fetch_full_config", fetch_full_config)
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_fetch_local_config(config_file):
+    """Test local config (default, env_vars, cmdconfig, cmdargs)"""
+    cmdargs = {"config": config_file}
+    local_config = ExperimentBuilder().fetch_local_config(cmdargs)
+
+    assert local_config['algorithms'] == 'random'
+    assert local_config['database']['host'] == 'mongodb://user:pass@localhost'
+    assert local_config['database']['name'] == 'orion_test'
+    assert local_config['database']['type'] == 'mongodb'
+    assert local_config['max_trials'] == 100
+    assert local_config['name'] == 'voila_voici'
+    assert local_config['pool_size'] == 1
+
+
+@pytest.mark.usefixtures("clean_db")
+def test_fetch_local_config_from_incomplete_config(incomplete_config_file):
+    """Test local config with incomplete user configuration file
+    (default, env_vars, cmdconfig, cmdargs)
+
+    This is to ensure merge_configs update properly the subconfigs
+    """
+    cmdargs = {"config": incomplete_config_file}
+    local_config = ExperimentBuilder().fetch_local_config(cmdargs)
+
+    assert local_config['algorithms'] == 'random'
+    assert local_config['database']['host'] == 'mongodb://user:pass@localhost'
+    assert local_config['database']['name'] == 'orion'
+    assert local_config['database']['type'] == 'incomplete'
+    assert local_config['max_trials'] == float('inf')
+    assert local_config['name'] == 'incomplete'
+    assert local_config['pool_size'] == 10
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_fetch_db_config_no_hit(config_file, random_dt):
+    """Verify that fetch_db_config returns an empty dict when the experiment is not in db"""
+    cmdargs = {'name': 'supernaekei', 'config': config_file}
+    db_config = ExperimentBuilder().fetch_db_config(cmdargs)
+    assert db_config == {}
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_fetch_db_config_hit(config_file, exp_config):
+    """Verify db config when experiment is in db"""
+    cmdargs = {'name': 'supernaedo2', 'config': config_file}
+    db_config = ExperimentBuilder().fetch_db_config(cmdargs)
+
+    assert db_config['name'] == exp_config[0][0]['name']
+    assert db_config['refers'] == exp_config[0][0]['refers']
+    assert db_config['metadata'] == exp_config[0][0]['metadata']
+    assert db_config['pool_size'] == exp_config[0][0]['pool_size']
+    assert db_config['max_trials'] == exp_config[0][0]['max_trials']
+    assert db_config['status'] == exp_config[0][0]['status']
+    assert db_config['algorithms'] == exp_config[0][0]['algorithms']
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_fetch_full_config_new_config(config_file, exp_config, random_dt):
+    """Verify full config with new config (causing branch)"""
+    cmdargs = {'name': 'supernaedo2',
+               'config': config_file,
+               'user_args': ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])",
+                             "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"],
+               'user_script': 'full_path/main.py'}
+    full_config = ExperimentBuilder().fetch_full_config(cmdargs)
+    cmdconfig = ExperimentBuilder().fetch_file_config(cmdargs)
+
+    full_config['metadata']['orion_version'] = exp_config[0][0]['metadata']['orion_version']
+
+    assert full_config['name'] == exp_config[0][0]['name']
+    assert full_config['refers'] == exp_config[0][0]['refers']
+    assert full_config['metadata']['datetime'] == exp_config[0][0]['metadata']['datetime']
+    assert full_config['metadata'] == exp_config[0][0]['metadata']
+    assert full_config['metadata'] == exp_config[0][0]['metadata']
+    assert full_config['metadata'] == exp_config[0][0]['metadata']
+    assert full_config['pool_size'] == cmdconfig['pool_size']
+    assert full_config['max_trials'] == cmdconfig['max_trials']
+    assert full_config['algorithms'] == cmdconfig['algorithms']
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_fetch_full_config_old_config(old_config_file, exp_config):
+    """Verify full config with old config (not causing branch)"""
+    cmdargs = {'name': 'supernaedo2',
+               'config': old_config_file,
+               'user_args': ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])",
+                             "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"],
+               'user_script': 'full_path/main.py'}
+
+    full_config = ExperimentBuilder().fetch_full_config(cmdargs)
+    cmdconfig = ExperimentBuilder().fetch_file_config(cmdargs)
+
+    full_config['metadata']['orion_version'] = exp_config[0][0]['metadata']['orion_version']
+
+    assert full_config['name'] == exp_config[0][0]['name']
+    assert full_config['refers'] == exp_config[0][0]['refers']
+    assert full_config['metadata'] == exp_config[0][0]['metadata']
+    assert full_config['pool_size'] == cmdconfig['pool_size']
+    assert full_config['max_trials'] == cmdconfig['max_trials']
+    assert full_config['algorithms'] == cmdconfig['algorithms']
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_fetch_full_config_no_hit(config_file, exp_config, random_dt):
+    """Verify full config when experiment not in db"""
+    cmdargs = {'name': 'supernaekei', 'config': config_file}
+    full_config = ExperimentBuilder().fetch_full_config(cmdargs)
+
+    assert full_config['name'] == 'supernaekei'
+    assert full_config['algorithms'] == 'random'
+    assert full_config['max_trials'] == 100
+    assert full_config['name'] == 'supernaekei'
+    assert full_config['pool_size'] == 1
+    assert full_config['metadata']['datetime'] == random_dt
+    assert full_config['metadata']['user'] == 'tsirif'
+    assert 'refers' not in full_config
+    assert 'status' not in full_config
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_build_view_from_no_hit(config_file, create_db_instance, exp_config):
+    """Try building experiment view when not in db"""
+    cmdargs = {'name': 'supernaekei', 'config': config_file}
+
+    with pytest.raises(ValueError) as exc_info:
+        ExperimentBuilder().build_view_from(cmdargs)
+    assert "No experiment with given name 'supernaekei' for user 'tsirif'" in str(exc_info.value)
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_build_view_from(config_file, create_db_instance, exp_config):
+    """Try building experiment view when in db"""
+    cmdargs = {'name': 'supernaedo2', 'config': config_file}
+    exp_view = ExperimentBuilder().build_view_from(cmdargs)
+
+    assert exp_view._experiment._init_done is True
+    assert exp_view._experiment._db._database is create_db_instance
+    assert exp_view._id == exp_config[0][0]['_id']
+    assert exp_view.name == exp_config[0][0]['name']
+    assert exp_view.refers == exp_config[0][0]['refers']
+    assert exp_view.metadata == exp_config[0][0]['metadata']
+    assert exp_view._experiment._last_fetched == exp_config[0][0]['metadata']['datetime']
+    assert exp_view.pool_size == exp_config[0][0]['pool_size']
+    assert exp_view.max_trials == exp_config[0][0]['max_trials']
+    assert exp_view.status == exp_config[0][0]['status']
+    assert exp_view.algorithms.configuration == exp_config[0][0]['algorithms']
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_build_from_no_hit(config_file, create_db_instance, exp_config, random_dt):
+    """Try building experiment when not in db"""
+    cmdargs = {'name': 'supernaekei', 'config': config_file,
+               'user_args': ['x~uniform(0,10)']}
+
+    with pytest.raises(ValueError) as exc_info:
+        ExperimentBuilder().build_view_from(cmdargs)
+    assert "No experiment with given name 'supernaekei' for user 'tsirif'" in str(exc_info.value)
+
+    exp = ExperimentBuilder().build_from(cmdargs)
+
+    assert exp._init_done is True
+    assert exp._db is create_db_instance
+    assert exp.name == cmdargs['name']
+    assert exp.refers is None
+    assert exp.metadata['datetime'] == random_dt
+    assert exp.metadata['user'] == 'tsirif'
+    assert exp.metadata['user_args'] == cmdargs['user_args']
+    assert exp._last_fetched == random_dt
+    assert exp.pool_size == 1
+    assert exp.max_trials == 100
+    assert exp.status == 'pending'
+    assert exp.algorithms.configuration == {'random': {}}
+
+
+@pytest.mark.usefixtures("version_01")
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_build_from_hit(old_config_file, create_db_instance, exp_config):
+    """Try building experiment when in db (no branch)"""
+    cmdargs = {'name': 'supernaedo2',
+               'config': old_config_file,
+               'user_args': ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])",
+                             "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"],
+               'user_script': 'full_path/main.py'}
+
+    # Test that experiment already exists
+    ExperimentBuilder().build_view_from(cmdargs)
+    exp = ExperimentBuilder().build_from(cmdargs)
+
+    assert exp._init_done is True
+    assert exp._db is create_db_instance
+    assert exp._id == exp_config[0][0]['_id']
+    assert exp.name == exp_config[0][0]['name']
+    assert exp.refers == exp_config[0][0]['refers']
+    assert exp.metadata == exp_config[0][0]['metadata']
+    assert exp._last_fetched == exp_config[0][0]['metadata']['datetime']
+    assert exp.pool_size == exp_config[0][0]['pool_size']
+    assert exp.max_trials == exp_config[0][0]['max_trials']
+    assert exp.status == exp_config[0][0]['status']
+    assert exp.algorithms.configuration == exp_config[0][0]['algorithms']
+
+
+@pytest.mark.usefixtures("version_01")
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_build_from_config_no_hit(config_file, create_db_instance, exp_config, random_dt):
+    """Try building experiment from config when not in db"""
+    cmdargs = {'name': 'supernaekei', 'config': config_file,
+               'user_args': ['x~uniform(0,10)']}
+
+    with pytest.raises(ValueError) as exc_info:
+        ExperimentBuilder().build_view_from(cmdargs)
+    assert "No experiment with given name 'supernaekei' for user 'tsirif'" in str(exc_info.value)
+
+    full_config = ExperimentBuilder().fetch_full_config(cmdargs)
+    exp = ExperimentBuilder().build_from_config(full_config)
+
+    assert exp._init_done is True
+    assert exp._db is create_db_instance
+    assert exp.name == cmdargs['name']
+    assert exp.refers is None
+    assert exp.metadata['datetime'] == random_dt
+    assert exp.metadata['user'] == 'tsirif'
+    assert exp.metadata['user_args'] == cmdargs['user_args']
+    assert exp._last_fetched == random_dt
+    assert exp.pool_size == 1
+    assert exp.max_trials == 100
+    assert exp.status == 'pending'
+    assert exp.algorithms.configuration == {'random': {}}
+
+
+@pytest.mark.usefixtures("clean_db")
+@pytest.mark.usefixtures("null_db_instances")
+@pytest.mark.usefixtures("with_user_tsirif")
+def test_build_from_config_hit(old_config_file, create_db_instance, exp_config):
+    """Try building experiment from config when in db (no branch)"""
+    cmdargs = {'name': 'supernaedo2',
+               'config': old_config_file,
+               'user_args': ["--encoding_layer~choices(['rnn', 'lstm', 'gru'])",
+                             "--decoding_layer~choices(['rnn', 'lstm_with_attention', 'gru'])"],
+               'user_script': 'full_path/main.py'}
+
+    # Test that experiment already exists
+    ExperimentBuilder().build_view_from(cmdargs)
+
+    exp_view = ExperimentBuilder().build_view_from(cmdargs)
+    exp = ExperimentBuilder().build_from_config(exp_view.configuration)
+
+    assert exp._init_done is True
+    assert exp._db is create_db_instance
+    assert exp._id == exp_config[0][0]['_id']
+    assert exp.name == exp_config[0][0]['name']
+    assert exp.refers == exp_config[0][0]['refers']
+    assert exp.metadata == exp_config[0][0]['metadata']
+    assert exp._last_fetched == exp_config[0][0]['metadata']['datetime']
+    assert exp.pool_size == exp_config[0][0]['pool_size']
+    assert exp.max_trials == exp_config[0][0]['max_trials']
+    assert exp.status == exp_config[0][0]['status']
+    assert exp.algorithms.configuration == exp_config[0][0]['algorithms']

--- a/tests/unittests/core/io/test_experiment_builder.py
+++ b/tests/unittests/core/io/test_experiment_builder.py
@@ -11,7 +11,7 @@ from orion.core.io.experiment_builder import ExperimentBuilder
 def test_fetch_local_config(config_file):
     """Test local config (default, env_vars, cmdconfig, cmdargs)"""
     cmdargs = {"config": config_file}
-    local_config = ExperimentBuilder().fetch_local_config(cmdargs)
+    local_config = ExperimentBuilder().fetch_full_config(cmdargs, use_db=False)
 
     assert local_config['algorithms'] == 'random'
     assert local_config['database']['host'] == 'mongodb://user:pass@localhost'
@@ -30,7 +30,7 @@ def test_fetch_local_config_from_incomplete_config(incomplete_config_file):
     This is to ensure merge_configs update properly the subconfigs
     """
     cmdargs = {"config": incomplete_config_file}
-    local_config = ExperimentBuilder().fetch_local_config(cmdargs)
+    local_config = ExperimentBuilder().fetch_full_config(cmdargs, use_db=False)
 
     assert local_config['algorithms'] == 'random'
     assert local_config['database']['host'] == 'mongodb://user:pass@localhost'

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -3,6 +3,7 @@
 """Example usage and tests for :mod:`orion.core.io.resolve_config`."""
 
 import os
+import socket
 
 import pytest
 
@@ -23,7 +24,7 @@ def test_fetch_default_options():
     default_config = resolve_config.fetch_default_options()
 
     assert default_config['algorithms'] == 'random'
-    assert default_config['database']['host'] == '127.0.1.1'
+    assert default_config['database']['host'] == socket.gethostbyname(socket.gethostname())
     assert default_config['database']['name'] == 'orion'
     assert default_config['database']['type'] == 'MongoDB'
 

--- a/tests/unittests/core/io/test_resolve_config.py
+++ b/tests/unittests/core/io/test_resolve_config.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Example usage and tests for :mod:`orion.core.io.resolve_config`."""
+
+
+import os
+
+import orion.core.io.resolve_config as resolve_config
+
+
+def test_fetch_default_options():
+    """Verify default options"""
+    default_config = resolve_config.fetch_default_options()
+
+    assert default_config['algorithms'] == 'random'
+    assert default_config['database']['host'] == '127.0.1.1'
+    assert default_config['database']['name'] == 'orion'
+    assert default_config['database']['type'] == 'MongoDB'
+
+    assert default_config['max_trials'] == float('inf')
+    assert default_config['name'] is None
+    assert default_config['pool_size'] == 10
+
+
+def test_fetch_env_vars():
+    """Verify env vars are fetched properly"""
+    env_vars_config = resolve_config.fetch_env_vars()
+    assert env_vars_config == {'database': {}}
+
+    db_name = "orion_test"
+
+    os.environ['ORION_DB_NAME'] = db_name
+
+    env_vars_config = resolve_config.fetch_env_vars()
+    assert env_vars_config == {'database': {'name': 'orion_test'}}
+
+    db_type = "MongoDB"
+    os.environ['ORION_DB_TYPE'] = db_type
+
+    env_vars_config = resolve_config.fetch_env_vars()
+    assert env_vars_config == {'database': {'name': db_name, 'type': db_type}}
+
+
+def test_fetch_config_no_hit():
+    """Verify fetch_config returns empty dict on no config file path"""
+    config = resolve_config.fetch_config({"config": ""})
+    assert config == {}
+
+
+def test_fetch_config(config_file):
+    """Verify fetch_config returns valid dictionnary"""
+    config = resolve_config.fetch_config({"config": config_file})
+
+    assert config['algorithms'] == 'random'
+    assert config['database']['host'] == 'mongodb://user:pass@localhost'
+    assert config['database']['name'] == 'orion_test'
+    assert config['database']['type'] == 'mongodb'
+
+    assert config['max_trials'] == 100
+    assert config['name'] == 'voila_voici'
+    assert config['pool_size'] == 1
+
+
+def test_merge_configs_update_two():
+    """Ensure update on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'a': 3}
+
+    m = resolve_config.merge_configs(a, b)
+
+    assert m == {'a': 3, 'b': 2}
+
+
+def test_merge_configs_update_three():
+    """Ensure two updates on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'a': 3}
+    c = {'b': 4}
+
+    m = resolve_config.merge_configs(a, b, c)
+
+    assert m == {'a': 3, 'b': 4}
+
+
+def test_merge_configs_update_four():
+    """Ensure three updates on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'a': 3}
+    c = {'b': 4}
+    d = {'a': 5, 'b': 6}
+
+    m = resolve_config.merge_configs(a, b, c, d)
+
+    assert m == {'a': 5, 'b': 6}
+
+
+def test_merge_configs_extend_two():
+    """Ensure extension on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'c': 3}
+
+    m = resolve_config.merge_configs(a, b)
+
+    assert m == {'a': 1, 'b': 2, 'c': 3}
+
+
+def test_merge_configs_extend_three():
+    """Ensure two extensions on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'c': 3}
+    c = {'d': 4}
+
+    m = resolve_config.merge_configs(a, b, c)
+
+    assert m == {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+
+
+def test_merge_configs_extend_four():
+    """Ensure three extensions on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'c': 3}
+    c = {'d': 4}
+    d = {'e': 5}
+
+    m = resolve_config.merge_configs(a, b, c, d)
+
+    assert m == {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5}
+
+
+def test_merge_configs_update_extend_two():
+    """Ensure update and extension on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'b': 3, 'c': 4}
+
+    m = resolve_config.merge_configs(a, b)
+
+    assert m == {'a': 1, 'b': 3, 'c': 4}
+
+
+def test_merge_configs_update_extend_three():
+    """Ensure two updates and extensions on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'b': 3, 'c': 4}
+    c = {'a': 5, 'd': 6}
+
+    m = resolve_config.merge_configs(a, b, c)
+
+    assert m == {'a': 5, 'b': 3, 'c': 4, 'd': 6}
+
+
+def test_merge_configs_update_extend_four():
+    """Ensure three updates and extensions on first level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'b': 3, 'c': 4}
+    c = {'a': 5, 'd': 6}
+    d = {'d': 7, 'e': 8}
+
+    m = resolve_config.merge_configs(a, b, c, d)
+
+    assert m == {'a': 5, 'b': 3, 'c': 4, 'd': 7, 'e': 8}
+
+
+def test_merge_sub_configs_update_two():
+    """Ensure updating to second level is fine"""
+    a = {'a': 1, 'b': 2}
+    b = {'b': {'c': 3}}
+
+    m = resolve_config.merge_configs(a, b)
+
+    assert m == {'a': 1, 'b': {'c': 3}}
+
+
+def test_merge_sub_configs_sub_update_two():
+    """Ensure updating on second level is fine"""
+    a = {'a': 1, 'b': {'c': 2}}
+    b = {'b': {'c': 3}}
+
+    m = resolve_config.merge_configs(a, b)
+
+    assert m == {'a': 1, 'b': {'c': 3}}
+
+    a = {'a': 1, 'b': {'c': 2, 'd': 3}}
+    b = {'b': {'c': 4}}
+
+    m = resolve_config.merge_configs(a, b)
+
+    assert m == {'a': 1, 'b': {'c': 4, 'd': 3}}
+
+
+def test_merge_sub_configs_sub_extend_two():
+    """Ensure updating to third level from second level is fine"""
+    a = {'a': 1, 'b': {'c': 2}}
+    b = {'d': {'e': 3}}
+
+    m = resolve_config.merge_configs(a, b)
+
+    assert m == {'a': 1, 'b': {'c': 2}, 'd': {'e': 3}}
+
+    a = {'a': 1, 'b': {'c': 2, 'd': 3}}
+    b = {'b': {'e': {'f': 4}}}
+
+    m = resolve_config.merge_configs(a, b)
+
+    assert m == {'a': 1, 'b': {'c': 2, 'd': 3, 'e': {'f': 4}}}
+
+
+def test_merge_sub_configs_update_three():
+    """Ensure updating twice to third level from second level is fine"""
+    a = {'a': 1, 'b': {'c': 2}}
+    b = {'b': {'c': 3}}
+    c = {'b': {'c': {'d': 4}}}
+
+    m = resolve_config.merge_configs(a, b, c)
+
+    assert m == {'a': 1, 'b': {'c': {'d': 4}}}
+
+    a = {'a': 1, 'b': {'c': 2, 'd': 3}}
+    b = {'b': {'c': 4}}
+    c = {'b': {'c': {'e': 5}}}
+
+    m = resolve_config.merge_configs(a, b, c)
+
+    assert m == {'a': 1, 'b': {'c': {'e': 5}, 'd': 3}}
+
+
+def test_infer_versioning_metadata():
+    """Verify infer_versioning_metadata does nothing so far
+
+    Test should be broken once the function is implemented
+    """
+    metadata = {'hello': {'world': 0}}
+    assert resolve_config.infer_versioning_metadata(metadata) == metadata

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -324,13 +324,11 @@ class TestConfigProperty(object):
             exp.configure(new_config)
         assert 'inconsistent' in str(exc_info.value)
 
-    def test_inconsistent_3_set_before_init_no_hit(self, random_dt, new_config):
+    def test_not_inconsistent_3_set_before_init_no_hit(self, random_dt, new_config):
         """Test inconsistent configuration because of datetime."""
         exp = Experiment(new_config['name'])
         new_config['metadata']['datetime'] = 123
-        with pytest.raises(ValueError) as exc_info:
-            exp.configure(new_config)
-        assert 'inconsistent' in str(exc_info.value)
+        exp.configure(new_config)
 
     def test_get_after_init_plus_hit_no_diffs(self, exp_config):
         """Return a configuration dict according to an experiment object.

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -151,9 +151,8 @@ class TestInitExperiment(object):
         assert exp.name == 'supernaekei'
         assert exp.refers is None
         assert exp.metadata['user'] == 'tsirif'
-        assert exp.metadata['datetime'] == random_dt
         assert exp._last_fetched == random_dt
-        assert len(exp.metadata) == 2
+        assert len(exp.metadata) == 1
         assert exp.pool_size is None
         assert exp.max_trials is None
         assert exp.algorithms is None
@@ -170,9 +169,8 @@ class TestInitExperiment(object):
         assert exp.name == 'supernaedo2'
         assert exp.refers is None
         assert exp.metadata['user'] == 'bouthilx'
-        assert exp.metadata['datetime'] == random_dt
         assert exp._last_fetched == random_dt
-        assert len(exp.metadata) == 2
+        assert len(exp.metadata) == 1
         assert exp.pool_size is None
         assert exp.max_trials is None
         assert exp.algorithms is None
@@ -222,8 +220,7 @@ class TestConfigProperty(object):
         assert cfg['name'] == 'supernaekei'
         assert cfg['refers'] is None
         assert cfg['metadata']['user'] == 'tsirif'
-        assert cfg['metadata']['datetime'] == random_dt
-        assert len(cfg['metadata']) == 2
+        assert len(cfg['metadata']) == 1
         assert cfg['pool_size'] is None
         assert cfg['max_trials'] is None
         assert cfg['algorithms'] is None

--- a/tests/unittests/core/test_experiment.py
+++ b/tests/unittests/core/test_experiment.py
@@ -369,11 +369,11 @@ class TestConfigProperty(object):
         initialized and needs to be rebuilt.
         """
         exp = Experiment(new_config['name'])
-        assert exp.status is None
+        assert exp.id is None
         # Another experiment gets configured first
         experiment_count_before = exp._db.count("experiments")
         naughty_little_exp = Experiment(new_config['name'])
-        assert naughty_little_exp.status is None
+        assert naughty_little_exp.id is None
         naughty_little_exp.configure(new_config)
         assert naughty_little_exp._init_done is True
         assert exp._init_done is False
@@ -395,13 +395,10 @@ class TestConfigProperty(object):
         """
         # Another experiment gets configured first
         naughty_little_exp = Experiment(new_config['name'])
-        assert naughty_little_exp.status is None
+        assert naughty_little_exp.id is None
         experiment_count_before = naughty_little_exp._db.count("experiments")
         naughty_little_exp.configure(copy.deepcopy(new_config))
         assert naughty_little_exp._init_done is True
-
-        import pprint
-        pprint.pprint(new_config)
 
         exp = Experiment(new_config['name'])
         assert exp._init_done is False


### PR DESCRIPTION
Depends on #96

This is the largest of the pull requests for feature/evc on my side. The refactoring of the building process of experiments was required because otherwise the creation of the experiment version control tree would be more complicated and require additional code duplication. 

## (main commit) Refactor experiment build into ExperimentBuilder 

Why:

The instantiation of an `Experiment` is not a trivial process when the
user request an experiment with specific options. One can easily create
a new experiment with `ExperimentView('some_experiment_name')`, but the
configuration of a _writable_ experiment is less straighforward. This is
because there is many sources of configuration and they have a strict
hierarchy. This commit attempts to unify the process of building an
experiment into a single module/class.

How:

The builder can build an experiment only provided the command args. All
fetch of other source of configuration are executed internally. The
implementation is less efficient to favor simplicity. Yet the loss of
efficiency should not impact the global execution as creating an
experiment happens rarely and requires only a few query on the
database. This is also true in the context of experiment version control
trees.

The builder is built as a class such that the methods' efficiency could
be improved latter on by caching configuration fetches to avoid
duplicate fetches.

--------

### Remove metadata/datetime check on init

Why:

This check was (I guess) to make sure the configuration was partly
initialized by the experiment itself which is not yet fully configured.
I don't think such a security measure is necessary and it makes
configuration of experiments more tedious. All information we want is
from default_config, env_vars_config, db_config, cmdconfig and cmdargs.
Attributes set by the experiment at initialization (not configuration)
does not need and should not pollute this configuration. username and
datetime is now set inside ExperimentBuilder.fetch_full_config is not
already available.

Note:

What about adding those metadata as a metadata config inside the
hierarchy? Something like

default <  env_vars < metadata < db_config < cmdconfig < cmdargs

----

### Do no set experiment on pending by default 

Why:

If an experiment is broken, it should not be automatically resumed
simply by fetching the experiment from database and configuring it.
Also, if the experiment is done and the termination criterion does not
change, then it should not be set to pending automatically.

How:

At configuration time, test if status is None or status is not broken
and the termination criterion is False. If yes, then set status to
pending.

----

### Unify resolve_config.merges

Why:

There is many different fetches and merges on the configuration
dictionaries. They more or less all share the same logic, so they are
easily to combine together to avoid code duplication.

How:

A new generic function `merge_configs` is added to merge any kind of
dictionaries with a relation B overwrites A recursively.

----

###  Move and refactor resolve_config 

Why:

The functionalities of resolve_config while strongly related to `cli`
are mostly related to parsing of configuration. All builders are
currently implemented in `orion.core.io`, including
`orion.core.experiment_builder` which will make heavy use of
`resolve_config`. Furthermore, by refactoring the experiment building
process, most of the use of `resolve_config` will be moved from `cli`
to `orion.core.experiment_builder`.

How:

Move file `orion.core.cli.resolve_config` to `orion.core.io.resolve_config`.
Move class `OrionArgParser` with functions `get_basic_args_group` and
`get_user_args_group` to new submodule `orion.core.cli.base`.

All `cli` modules are modified accordingly.