### PR TITLE
Adapt MongoDB to support options

### DIFF
--- a/tests/unittests/core/mongodb_test.py
+++ b/tests/unittests/core/mongodb_test.py
@@ -82,8 +82,8 @@ class TestConnection(object):
 
     def test_overwrite_uri(self):
         """Check the case when connecting with ready `uri`."""
-        orion_db = MongoDB('mongodb://lala:pass@localhost:1231/orion',
-                           port=27017, name='orion_test', username='user',
+        orion_db = MongoDB('mongodb://user:pass@localhost:27017/orion_test',
+                           port=1231, name='orion', username='lala',
                            password='pass')
         assert orion_db.host == 'localhost'
         assert orion_db.port == 27017


### PR DESCRIPTION
This PR gives support for options necessary for the use of Atlas MongoDB DaaS or the database at Mila.

### Why:

`MongoDB` would only pass host, port, username and password to `MongoClient`. The user could not use any option like `ssl` or `replicaSet`.

Support for options are mandatory to access secured databases.

### How:

Pass the URI rather than the parsed host when specified by the user.

### Note:

There is no support for specific options through the interface. Options need to be specified in the URI for now.

### Note:

`pymongo` would overwrite single arguments passed by those in the URI if they are different. The behavior of `MongoDB` is reversed in this commit to be coherent with `pymongo`.