### PR TITLE
feature/add_others_to_allowedtypes

### DIFF
--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -132,7 +132,7 @@ class Trial(object):
         function or of an 'constraint' expression.
         """
 
-        allowed_types = ('objective', 'constraint', 'gradient')
+        allowed_types = ('objective', 'constraint', 'gradient', 'other')
 
     class Param(Value):
         """Types for a `Param` can be either an integer (discrete value),

--- a/src/orion/core/worker/trial.py
+++ b/src/orion/core/worker/trial.py
@@ -132,7 +132,7 @@ class Trial(object):
         function or of an 'constraint' expression.
         """
 
-        allowed_types = ('objective', 'constraint', 'gradient', 'other')
+        allowed_types = ('objective', 'constraint', 'gradient', 'statistics')
 
     class Param(Value):
         """Types for a `Param` can be either an integer (discrete value),


### PR DESCRIPTION
adding `others` to allowed-types in trial 

where I tried to pass a statistic of the run as a dictionary object to the results list in orion.results but not allowed too, based on this error

```Traceback (most recent call last):
  File "/home/keatext/.local/share/virtualenvs/keanet-tbWY-zLv/bin/orion", line 11, in <module>
    load_entry_point('orion.core', 'console_scripts', 'orion')()
  File "/home/keatext/code/orion/src/orion/core/cli/__init__.py", line 35, in main
    orion_parser.execute(argv)
  File "/home/keatext/code/orion/src/orion/core/cli/resolve_config.py", line 137, in execute
    function(args)
  File "/home/keatext/code/orion/src/orion/core/cli/hunt.py", line 53, in main
    _execute(args, config)
  File "/home/keatext/code/orion/src/orion/core/cli/hunt.py", line 81, in _execute
    workon(experiment)
  File "/home/keatext/code/orion/src/orion/core/worker/__init__.py", line 46, in workon
    consumer.consume(trial)
  File "/home/keatext/code/orion/src/orion/core/worker/consumer.py", line 71, in consume
    completed_trial = self._consume(trial, workdirname)
  File "/home/keatext/code/orion/src/orion/core/worker/consumer.py", line 117, in _consume
    value=res['value']) for res in results]
  File "/home/keatext/code/orion/src/orion/core/worker/consumer.py", line 117, in <listcomp>
    value=res['value']) for res in results]
  File "/home/keatext/code/orion/src/orion/core/worker/trial.py", line 98, in __init__
    setattr(self, attrname, value)
  File "/home/keatext/code/orion/src/orion/core/worker/trial.py", line 127, in type
    type_, self.allowed_types))
ValueError: Given type, statistics, not one of: ('objective', 'constraint', 'gradient')```