### PR TITLE
Add --debug option to isolate command line invocations

### DIFF
--- a/src/orion/core/cli/base.py
+++ b/src/orion/core/cli/base.py
@@ -42,6 +42,10 @@ class OrionArgsParser:
             action='count', default=0,
             help="logging levels of information about the process (-v: INFO. -vv: DEBUG)")
 
+        self.parser.add_argument(
+            '-d', '--debug', action='store_true',
+            help="Use debugging mode with EphemeralDB.")
+
         self.subparsers = self.parser.add_subparsers(help='sub-command help')
 
     def get_subparsers(self):

--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -1,0 +1,440 @@
+# -*- coding: utf-8 -*-
+"""
+:mod:`orion.core.io.database.ephemeraldb` -- Non permanent database
+===================================================================
+
+.. module:: database
+   :platform: Unix
+   :synopsis: Implement non permanent version of :class:`orion.core.io.database.AbstractDB`
+
+"""
+from collections import defaultdict
+import copy
+
+from orion.core.io.database import AbstractDB, DuplicateKeyError
+
+
+class EphemeralDB(AbstractDB):
+    """Non permanent database
+
+    This database is meant for debugging purposes. It only lives through one execution and all
+    information saved during it is lost when the process is terminated.
+
+    .. seealso:: :class:`orion.core.io.database.AbstractDB` for more on attributes.
+
+    """
+
+    @property
+    def is_connected(self):
+        """Return true, always."""
+        return True
+
+    def initiate_connection(self):
+        """Create the dictionary which serve as an ephemeral database"""
+        self._db = defaultdict(EphemeralCollection)
+
+    def close_connection(self):
+        """Remove the dictionary"""
+        self._db = None
+
+    def ensure_index(self, collection_name, keys, unique=False):
+        """Create given indexes if they do not already exist in database.
+
+        Indexes are only created if `unique` is True.
+        """
+        self._db[collection_name].create_index(keys, unique=unique)
+
+    def write(self, collection_name, data, query=None):
+        """Write new information to a collection. Perform insert or update.
+
+        .. seealso:: :meth:`AbstractDB.write` for argument documentation.
+
+        """
+        dbcollection = self._db[collection_name]
+
+        if query is None:
+            # We can assume that we do not want to update.
+            # So we do insert_many instead.
+            if type(data) not in (list, tuple):
+                data = [data]
+            return dbcollection.insert_many(documents=data)
+
+        update_data = {'$set': data}
+
+        return dbcollection.update_many(query=query,
+                                        update=update_data)
+
+    def read(self, collection_name, query=None, selection=None):
+        """Read a collection and return a value according to the query.
+
+        .. seealso:: :meth:`AbstractDB.read` for argument documentation.
+
+        """
+        dbcollection = self._db[collection_name]
+
+        dbdocs = dbcollection.find(query, selection)
+
+        return dbdocs
+
+    def read_and_write(self, collection_name, query, data, selection=None):
+        """Read a collection's document and update the found document.
+
+        Returns the updated document, or None if nothing found.
+
+        .. seealso:: :meth:`AbstractDB.read_and_write` for
+                     argument documentation.
+
+        """
+        dbdoc = self.read(collection_name, query)
+        if not dbdoc:
+            return None
+
+        id_query = {'_id': dbdoc[0]['_id']}
+        self.write(collection_name, data, id_query)
+        return self.read(collection_name, id_query)[0]
+
+    def count(self, collection_name, query=None):
+        """Count the number of documents in a collection which match the `query`.
+
+        .. seealso:: :meth:`AbstractDB.count` for argument documentation.
+
+        """
+        dbcollection = self._db[collection_name]
+        return dbcollection.count(query=query)
+
+    def remove(self, collection_name, query):
+        """Delete from a collection document[s] which match the `query`.
+
+        .. seealso:: :meth:`AbstractDB.remove` for argument documentation.
+
+        """
+        dbcollection = self._db[collection_name]
+
+        return dbcollection.delete_many(query=query)
+
+
+class EphemeralCollection(object):
+    """Non permanent collection
+
+    This collection is meant for debugging purposes within the EphemeralDB.
+
+    .. seealso:: :class:`orion.core.io.database.ephemeraldb.EphemeralDB` for database object.
+
+    """
+
+    def __init__(self):
+        """Initialise the collection, with no documents and only _id unique index."""
+        self._documents = []
+        self._indexes = dict()
+        self.create_index('_id', unique=True)
+
+    def create_index(self, keys, unique=False):
+        """Create given indexes if they do not already exist for this collection.
+
+        Indexes are only created if `unique` is True.
+        """
+        # turn single key into list for coherence
+        if not isinstance(keys, (list, tuple)):
+            keys = [(keys, None)]
+
+        keys = tuple(key for (key, order) in keys)
+        if unique and keys not in self._indexes:
+            self._indexes[keys] = []
+
+    def find(self, query=None, selection=None):
+        """Find documents in the collection and return a value according to the query.
+
+        .. seealso:: :meth:`AbstractDB.read` for argument documentation.
+
+        """
+        found_documents = []
+        for document in self._documents:
+            if document.match(query):
+                found_documents.append(document.select(selection))
+
+        return found_documents
+
+    def _validate_index(self, document):
+        """Validate index values of a document
+
+        :raises: :exc:`DuplicateKeyError`: if the document contains unique indexes which are already
+        present in the database.
+        """
+        for index, values in self._indexes.items():
+            document_values = document.select({key: 1 for key in index})
+            if document_values in values:
+                raise DuplicateKeyError(
+                    "Duplicate key error: index={} value={}".format(index, document_values))
+
+    def _register_keys(self, document):
+        """Register index values of a new document"""
+        for index, values in self._indexes.items():
+            values.append(document.select({key: 1 for key in index}))
+
+    def _get_new_id(self):
+        """Return max id + 1"""
+        if self._documents:
+            return max(d['_id'] for d in self._documents) + 1
+
+        return 1
+
+    def insert_many(self, documents):
+        """Add new documents in the collection.
+
+        If the documents do not have a keys `_id`, they are assigned by default
+        the max id + 1.
+
+        :raises: :exc:`DuplicateKeyError`: if the document contains unique indexes which are
+            already present in the database.
+        """
+        for document in documents:
+            if '_id' not in document:
+                document['_id'] = self._get_new_id()
+            ephemeral_document = EphemeralDocument(document)
+            self._validate_index(ephemeral_document)
+            self._documents.append(ephemeral_document)
+            self._register_keys(ephemeral_document)
+
+        return True
+
+    def update_many(self, query, update):
+        """Update documents or upsert if not found.
+
+        If the document is not found, a new document which is the merge of query and update will be
+        inserted in the database.
+
+        :raises: :exc:`DuplicateKeyError`: if the update creates a duplication of unique indexes in
+            the database.
+        """
+        updates = 0
+        for document in self._documents:
+            if document.match(query):
+                document.update(update)
+                updates += 1
+
+        if not updates:
+            self._upsert(query, update)
+
+        return True
+
+    def _upsert(self, query, update):
+        """Insert the document when query was not found.
+
+        If update contains `$set`, then the new document is the combination of query and
+        update['$set'], otherwise the new document is `update`.
+        """
+        if "$set" in update:
+            new_document = copy.deepcopy(update["$set"])
+            new_document.update(query)
+        else:
+            new_document = update
+
+        self.insert_many([new_document])
+
+    def count(self, query=None):
+        """Count the number of documents in a collection which match the `query`.
+
+        .. seealso:: :meth:`AbstractDB.count` for argument documentation.
+        """
+        return len(self.find(query))
+
+    def delete_many(self, query=None):
+        """Delete from a collection document[s] which match the `query`.
+
+        .. seealso:: :meth:`AbstractDB.remove` for argument documentation.
+
+        """
+        retained_documents = []
+        for document in self._documents:
+            if not document.match(query):
+                retained_documents.append(document)
+
+        self._documents = retained_documents
+
+        return True
+
+    def drop(self):
+        """Drop the collection, removing all documents and indexes."""
+        self._documents = []
+        self._indexes = dict()
+
+
+class EphemeralDocument(object):
+    """Non permanent document
+
+    This document is meant for debugging purposes within the EphemeralDB.
+
+    .. seealso:: :class:`orion.core.io.database.ephemeraldb.EphemeralDB` for database object.
+
+    """
+
+    operators = {
+        "$in": (lambda a, b: a in b),
+        "$gte": (lambda a, b: a >= b),
+        "$gt": (lambda a, b: a > b)
+    }
+
+    def __init__(self, data):
+        """Initialise the document with a flattened version of the data"""
+        self._data = _flatten(data)
+
+    def match(self, query=None):
+        """Test if the document corresponds to a given query"""
+        if query is None or query == {}:
+            return True
+
+        query = _flatten(query)
+        for key, value in query.items():
+            if not self.match_key(key, value):
+                return False
+
+        return True
+
+    def match_key(self, key, value):
+        """Test if a data corresponding to the given key is in agreement with the given
+        value based on the operator defined within the key.
+
+        Default operator is equal when no operator is defined.
+        Other operators could be $in, $gte, $gt. They are defined
+        in the last section of the key. For example: `abc.def.$in` or `abc.def.$gte`.
+        """
+        if key.split(".")[-1] in self.operators:
+            operator = key.split(".")[-1]
+            key = ".".join(key.split(".")[:-1])
+
+            return key in self and self.operators[operator](self[key], value)
+
+        return key in self and self[key] == value
+
+    def _validate_keys(self, keys):
+        """Verify that all keys are 0 or 1 (with exception of _id) and convert them.
+
+        For simplicity, when keys are 0, the inverse set of keys for 1s is computed.
+
+        .. note ::
+
+            _id is set to 1 if not specified. Only _id may be set to 0 if other keys are set to 1.
+        """
+        keys_without_id = [key for key in keys if key != '_id']
+        n_keys = sum(keys[key] for key in keys_without_id)
+        if n_keys != 0 and n_keys != len(keys_without_id):
+            raise ValueError(
+                'Cannot mix selection with 1 and 0s except for _id: {}'.format(keys))
+
+        if n_keys == 0:
+            new_keys = dict((key, 1) for key in self._data.keys() if key not in keys)
+            new_keys['_id'] = keys.get('_id', 1)
+            keys = new_keys
+
+        return keys
+
+    def select(self, keys):
+        """Only select or only drop the specified keys
+
+        For a pair (key, value) in the dictionnary, value=0 means the key will not be included
+        while value=1 means it will.
+
+        All specified keys should be 0 or 1. They cannot have different values with the exception
+        of _id which can be specified to 0 while the others are at 1.
+
+        Parameters
+        ----------
+        keys: dict
+            Pairs of keys and 0 or 1s. When a key is associated with 1, it is kept in the selection,
+            otherwise it is dropped.
+
+        """
+        if not keys:
+            return _unflatten(self._data)
+
+        keys = _flatten(keys)
+        keys = self._validate_keys(keys)
+
+        selection = dict()
+
+        def key_is_match(key, selected_key):
+            """Test if key matches the selected key
+
+            key_is_match(abc.def.ghi, abc.def.ghi) -> True
+            key_is_match(abc.def.ghi, abc.def) -> True
+            key_is_match(abc.def.ghi, abc.de) -> False
+            key_is_match(abc.def.ghi, xyz) -> False
+            """
+            if not key.startswith(selected_key):
+                return False
+
+            if not key.replace(selected_key, ''):
+                return True
+
+            if key.replace(selected_key, '')[0] == ".":
+                return True
+
+            return False
+
+        for key, value in self._data.items():
+            for selected_key, include in keys.items():
+                if include and key_is_match(key, selected_key):
+                    selection[key] = value
+
+        return _unflatten(selection)
+
+    def update(self, data):
+        """Update the values of the document.
+
+        Parameters
+        ----------
+        data: dict
+            Dictionary of data to update the document. If `$set` is in
+            the data, the corresponding `data[$set]` will be used instead.
+
+        """
+        data = _flatten(data.get("$set", data))
+        self._data.update(data)
+
+    def to_dict(self):
+        """Convert the ephemeral document to a python dictionary"""
+        return self.select({})
+
+    def __getitem__(self, key):
+        """Get the item corresponding to the given key in the document"""
+        return self._data[key]
+
+    def __contains__(self, key):
+        """Test whether the given key is present in the document"""
+        return key in self._data
+
+
+def _flatten(dictionary):
+    def __flatten(dictionary):
+        if dictionary == {}:
+            return dictionary
+
+        key, value = dictionary.popitem()
+        if dict != type(value):
+            new_dictionary = {key: value}
+            new_dictionary.update(__flatten(dictionary))
+            return new_dictionary
+
+        flat_sub_dictionary = __flatten(value)
+        for flat_sub_key in list(flat_sub_dictionary.keys()):
+            flat_key = key + '.' + flat_sub_key
+            flat_sub_dictionary[flat_key] = flat_sub_dictionary.pop(flat_sub_key)
+
+        new_dictionary = flat_sub_dictionary
+        new_dictionary.update(_flatten(dictionary))
+        return new_dictionary
+
+    return __flatten(copy.deepcopy(dictionary))
+
+
+def _unflatten(dictionary):
+    unflattened_dictionary = dict()
+    for key, value in dictionary.items():
+        parts = key.split(".")
+        sub_dictionary = unflattened_dictionary
+        for part in parts[:-1]:
+            if part not in sub_dictionary:
+                sub_dictionary[part] = dict()
+            sub_dictionary = sub_dictionary[part]
+        sub_dictionary[parts[-1]] = value
+    return unflattened_dictionary

--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -224,8 +224,8 @@ class EphemeralCollection(object):
         update['$set'], otherwise the new document is `update`.
         """
         if "$set" in update:
-            new_document = copy.deepcopy(update["$set"])
-            new_document.update(query)
+            new_document = copy.deepcopy(query)
+            new_document.update(update["$set"])
         else:
             new_document = update
 

--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -403,7 +403,7 @@ def _flatten(dictionary):
             return dictionary
 
         key, value = dictionary.popitem()
-        if dict != type(value):
+        if not isinstance(value, dict) or not value:
             new_dictionary = {key: value}
             new_dictionary.update(__flatten(dictionary))
             return new_dictionary

--- a/src/orion/core/io/database/ephemeraldb.py
+++ b/src/orion/core/io/database/ephemeraldb.py
@@ -360,16 +360,9 @@ class EphemeralDocument(object):
             key_is_match(abc.def.ghi, abc.de) -> False
             key_is_match(abc.def.ghi, xyz) -> False
             """
-            if not key.startswith(selected_key):
-                return False
-
-            if not key.replace(selected_key, ''):
-                return True
-
-            if key.replace(selected_key, '')[0] == ".":
-                return True
-
-            return False
+            return (key == selected_key or
+                    (key.startswith(selected_key) and
+                     key.replace(selected_key, '')[0] == "."))
 
         for key, value in self._data.items():
             for selected_key, include in keys.items():

--- a/src/orion/core/io/experiment_builder.py
+++ b/src/orion/core/io/experiment_builder.py
@@ -201,6 +201,9 @@ class ExperimentBuilder(object):
         db_opts = local_config['database']
         dbtype = db_opts.pop('type')
 
+        if local_config.get("debug"):
+            dbtype = "EphemeralDB"
+
         # Information should be enough to infer experiment's name.
         log.debug("Creating %s database client with args: %s", dbtype, db_opts)
         try:

--- a/tests/unittests/core/test_ephemeraldb.py
+++ b/tests/unittests/core/test_ephemeraldb.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Collection of tests for :mod:`orion.core.io.database.ephemeraldb`."""
+
+from datetime import datetime
+
+import pytest
+
+from orion.core.io.database import Database
+from orion.core.io.database.ephemeraldb import EphemeralDB
+
+
+@pytest.fixture()
+def orion_db():
+    """Return EphemeralDB wrapper instance initiated with test opts."""
+    EphemeralDB.instance = None
+    orion_db = EphemeralDB()
+    return orion_db
+
+
+@pytest.fixture()
+def database(orion_db):
+    """Return the ephemeral database, a defaultdict of ephemeral collections"""
+    return orion_db._db
+
+
+@pytest.fixture()
+def clean_db(database, exp_config):
+    """Clean insert example experiment entries to collections."""
+    database['experiments'].drop()
+    database['experiments'].insert_many(exp_config[0])
+    database['trials'].drop()
+    database['trials'].insert_many(exp_config[1])
+    database['workers'].drop()
+    database['workers'].insert_many(exp_config[2])
+    database['resources'].drop()
+    database['resources'].insert_many(exp_config[3])
+
+
+@pytest.mark.usefixtures("clean_db")
+class TestEnsureIndex(object):
+    """Calls to :meth:`orion.core.io.database.ephemeraldb.EphemeralDB.ensure_index`."""
+
+    def test_new_index(self, orion_db):
+        """Index should be added to ephemeral database"""
+        assert ("status", ) not in orion_db._db['trials']._indexes
+
+        orion_db.ensure_index('trials', 'status', unique=False)
+        assert ("status", ) not in orion_db._db['trials']._indexes
+
+        orion_db.ensure_index('trials', 'status', unique=True)
+        assert ("status", ) in orion_db._db['trials']._indexes
+
+    def test_existing_index(self, orion_db):
+        """Index should be added to ephemeral database and reattempt should do nothing"""
+        assert ("status", ) not in orion_db._db['trials']._indexes
+
+        orion_db.ensure_index('trials', 'status', unique=True)
+        assert ("status", ) in orion_db._db['trials']._indexes
+
+        # reattempt
+        orion_db.ensure_index('trials', 'status', unique=True)
+        assert ("status", ) in orion_db._db['trials']._indexes
+
+    def test_ordered_index(self, orion_db):
+        """Sort order should be added to index"""
+        assert ("end_time", ) not in orion_db._db['trials']._indexes
+        orion_db.ensure_index('trials', [('end_time', Database.DESCENDING)], unique=True)
+        assert ("end_time", ) in orion_db._db['trials']._indexes
+
+    def test_compound_index(self, orion_db):
+        """Tuple of Index should be added as a compound index."""
+        assert ("name", "metadata.user") not in orion_db._db['experiments']._indexes
+        orion_db.ensure_index('experiments',
+                              [('name', Database.ASCENDING),
+                               ('metadata.user', Database.ASCENDING)], unique=True)
+        assert ("name", "metadata.user") in orion_db._db['experiments']._indexes
+
+
+@pytest.mark.usefixtures("clean_db")
+class TestRead(object):
+    """Calls to :meth:`orion.core.io.database.ephemeraldb.EphemeralDB.read`."""
+
+    def test_read_experiment(self, exp_config, orion_db):
+        """Fetch a whole experiment entries."""
+        loaded_config = orion_db.read(
+            'trials', {'experiment': 'supernaedo2', 'status': 'new'})
+        assert loaded_config == [exp_config[1][3], exp_config[1][4]]
+
+        loaded_config = orion_db.read(
+            'trials',
+            {'experiment': 'supernaedo2',
+             'submit_time': exp_config[1][3]['submit_time']})
+        assert loaded_config == [exp_config[1][3]]
+        assert loaded_config[0]['_id'] == exp_config[1][3]['_id']
+
+    def test_read_with_id(self, exp_config, orion_db):
+        """Query using ``_id`` key."""
+        loaded_config = orion_db.read('experiments', {'_id': exp_config[0][2]['_id']})
+        assert loaded_config == [exp_config[0][2]]
+
+    def test_read_default(self, exp_config, orion_db):
+        """Fetch value(s) from an entry."""
+        value = orion_db.read(
+            'experiments', {'name': 'supernaedo2', 'metadata.user': 'tsirif'},
+            selection={'algorithms': 1, '_id': 0})
+        assert value == [{'algorithms': exp_config[0][0]['algorithms']}]
+
+    def test_read_nothing(self, orion_db):
+        """Fetch value(s) from an entry."""
+        value = orion_db.read(
+            'experiments', {'name': 'not_found', 'metadata.user': 'tsirif'},
+            selection={'algorithms': 1})
+        assert value == []
+
+    def test_read_trials(self, exp_config, orion_db):
+        """Fetch value(s) from an entry."""
+        value = orion_db.read(
+            'trials',
+            {'experiment': 'supernaedo2',
+             'submit_time': {'$gte': datetime(2017, 11, 23, 0, 0, 0)}})
+        assert value == exp_config[1][2:7]
+
+        value = orion_db.read(
+            'trials',
+            {'experiment': 'supernaedo2',
+             'submit_time': {'$gt': datetime(2017, 11, 23, 0, 0, 0)}})
+        assert value == exp_config[1][3:7]
+
+
+@pytest.mark.usefixtures("clean_db")
+class TestWrite(object):
+    """Calls to :meth:`orion.core.io.database.ephemeraldb.EphemeralDB.write`."""
+
+    def test_insert_one(self, database, orion_db):
+        """Should insert a single new entry in the collection."""
+        item = {'exp_name': 'supernaekei',
+                'user': 'tsirif'}
+        count_before = database['experiments'].count()
+        # call interface
+        assert orion_db.write('experiments', item) is True
+        assert database['experiments'].count() == count_before + 1
+        value = database['experiments'].find({'exp_name': 'supernaekei'})[0]
+        assert value == item
+
+    def test_insert_many(self, database, orion_db):
+        """Should insert two new entry (as a list) in the collection."""
+        item = [{'exp_name': 'supernaekei2',
+                 'user': 'tsirif'},
+                {'exp_name': 'supernaekei3',
+                 'user': 'tsirif'}]
+        count_before = database['experiments'].count()
+        # call interface
+        assert orion_db.write('experiments', item) is True
+        assert database['experiments'].count() == count_before + 2
+        value = database['experiments'].find({'exp_name': 'supernaekei2'})[0]
+        assert value == item[0]
+        value = database['experiments'].find({'exp_name': 'supernaekei3'})[0]
+        assert value == item[1]
+
+    def test_update_many_default(self, database, orion_db):
+        """Should match existing entries, and update some of their keys."""
+        filt = {'metadata.user': 'tsirif'}
+        count_before = database['experiments'].count()
+        # call interface
+        assert orion_db.write('experiments', {'pool_size': 16}, filt) is True
+        assert database['experiments'].count() == count_before
+        value = list(database['experiments'].find({}))
+        assert value[0]['pool_size'] == 16
+        assert value[1]['pool_size'] == 16
+        assert value[2]['pool_size'] == 16
+        assert value[3]['pool_size'] == 2
+
+    def test_update_with_id(self, exp_config, database, orion_db):
+        """Query using ``_id`` key."""
+        filt = {'_id': exp_config[0][1]['_id']}
+        count_before = database['experiments'].count()
+        # call interface
+        assert orion_db.write('experiments', {'pool_size': 36}, filt) is True
+        assert database['experiments'].count() == count_before
+        value = list(database['experiments'].find())
+        assert value[0]['pool_size'] == 2
+        assert value[1]['pool_size'] == 36
+        assert value[2]['pool_size'] == 2
+
+    def test_upsert_with_id(self, database, orion_db):
+        """Query with a non-existent ``_id`` should upsert something."""
+        filt = {'_id': 'lalalathisisnew'}
+        count_before = database['experiments'].count()
+        # call interface
+        assert orion_db.write('experiments', {'pool_size': 66}, filt) is True
+        assert database['experiments'].count() == count_before + 1
+        value = list(database['experiments'].find(filt))
+        assert len(value) == 1
+        assert len(value[0]) == 2
+        assert value[0]['_id'] == 'lalalathisisnew'
+        assert value[0]['pool_size'] == 66
+
+
+@pytest.mark.usefixtures("clean_db")
+class TestReadAndWrite(object):
+    """Calls to :meth:`orion.core.io.database.ephemeraldb.EphemeralDB.read_and_write`."""
+
+    def test_read_and_write_one(self, database, orion_db, exp_config):
+        """Should read and update a single entry in the collection."""
+        # Make sure there is only one match
+        documents = orion_db.read(
+            'experiments',
+            {'name': 'supernaedo2', 'metadata.user': 'dendi'})
+        assert len(documents) == 1
+
+        # Find and update atomically
+        loaded_config = orion_db.read_and_write(
+            'experiments',
+            {'name': 'supernaedo2', 'metadata.user': 'dendi'},
+            {'pool_size': 'lalala'})
+        exp_config[0][3]['pool_size'] = 'lalala'
+        assert loaded_config == exp_config[0][3]
+
+    def test_read_and_write_many(self, database, orion_db, exp_config):
+        """Should update only one entry."""
+        # Make sure there is many matches
+        documents = orion_db.read('experiments', {'name': 'supernaedo2'})
+        assert len(documents) > 1
+
+        # Find many and update first one only
+        loaded_config = orion_db.read_and_write(
+            'experiments',
+            {'name': 'supernaedo2'},
+            {'pool_size': 'lalala'})
+
+        exp_config[0][0]['pool_size'] = 'lalala'
+        assert loaded_config == exp_config[0][0]
+
+        # Make sure it only changed the first document found
+        documents = orion_db.read('experiments', {'name': 'supernaedo2'})
+        assert documents[0]['pool_size'] == 'lalala'
+        assert documents[1]['pool_size'] != 'lalala'
+
+    def test_read_and_write_no_match(self, database, orion_db):
+        """Should return None when there is no match."""
+        loaded_config = orion_db.read_and_write(
+            'experiments',
+            {'name': 'lalala'},
+            {'pool_size': 'lalala'})
+
+        assert loaded_config is None
+
+
+@pytest.mark.usefixtures("clean_db")
+class TestRemove(object):
+    """Calls to :meth:`orion.core.io.database.ephemeraldb.EphemeralDB.remove`."""
+
+    def test_remove_many_default(self, exp_config, database, orion_db):
+        """Should match existing entries, and delete them all."""
+        filt = {'metadata.user': 'tsirif'}
+        count_before = database['experiments'].count()
+        count_filt = database['experiments'].count(filt)
+        # call interface
+        assert orion_db.remove('experiments', filt) is True
+        assert database['experiments'].count() == count_before - count_filt
+        assert database['experiments'].count() == 1
+        assert list(database['experiments'].find()) == [exp_config[0][3]]
+
+    def test_remove_with_id(self, exp_config, database, orion_db):
+        """Query using ``_id`` key."""
+        filt = {'_id': exp_config[0][0]['_id']}
+
+        count_before = database['experiments'].count()
+        # call interface
+        assert orion_db.remove('experiments', filt) is True
+        assert database['experiments'].count() == count_before - 1
+        assert database['experiments'].find() == exp_config[0][1:]
+
+
+@pytest.mark.usefixtures("clean_db")
+class TestCount(object):
+    """Calls :meth:`orion.core.io.database.ephemeraldb.EphemeralDB.count`."""
+
+    def test_count_default(self, exp_config, orion_db):
+        """Call just with collection name."""
+        found = orion_db.count('trials')
+        assert found == len(exp_config[1])
+
+    def test_count_query(self, exp_config, orion_db):
+        """Call with a query."""
+        found = orion_db.count('trials', {'status': 'completed'})
+        assert found == len([x for x in exp_config[1] if x['status'] == 'completed'])
+
+    def test_count_query_with_id(self, exp_config, orion_db):
+        """Call querying with unique _id."""
+        found = orion_db.count('trials', {'_id': exp_config[1][2]['_id']})
+        assert found == 1
+
+    def test_count_nothing(self, orion_db):
+        """Call with argument that will not find anything."""
+        found = orion_db.count('experiments', {'name': 'lalalanotfound'})
+        assert found == 0


### PR DESCRIPTION
## Add --debug option to orion hunt cli

#### Why:

It is tedious to debug with orion when using a database, especially when many modifications of invocations keep generating experiment branching events. With the EphemeralDB, we can isolate invocations and make the debugging process smoother.

#### How:

When --debug is specified, the dbtype of the config is overwritten with 'ephemeraldb'

See commit message cfb0bd9 for more information about the EphemeralDB