### PR TITLE
Add `hunt --worker-trials` argument

### DIFF
--- a/src/orion/core/cli/hunt.py
+++ b/src/orion/core/cli/hunt.py
@@ -16,6 +16,7 @@ from orion.core.cli import base as cli
 from orion.core.cli import evc as evc_cli
 from orion.core.io import resolve_config
 from orion.core.io.evc_builder import EVCBuilder
+from orion.core.io.experiment_builder import ExperimentBuilder
 from orion.core.worker import workon
 
 log = logging.getLogger(__name__)
@@ -29,8 +30,17 @@ def add_subparser(parser):
 
     orion_group.add_argument(
         '--max-trials', type=int, metavar='#',
-        help="number of jobs/trials to be completed "
+        help="number of trials to be completed for the experiment. This value "
+             "will be saved within the experiment configuration and reused "
+             "across all workers to determine experiment's completion. "
              "(default: %s)" % resolve_config.DEF_CMD_MAX_TRIALS[1])
+
+    orion_group.add_argument(
+        '--worker-trials', type=int, metavar='#',
+        help="number of trials to be completed for this worker. "
+             "If the experiment is completed, the worker will die even if it "
+             "did not reach its maximum number of trials "
+             "(default: %s)" % resolve_config.DEF_CMD_WORKER_TRIALS[1])
 
     orion_group.add_argument(
         "--pool-size", type=int, metavar='#',
@@ -50,5 +60,7 @@ def main(args):
     """Build experiment and execute hunt command"""
     args['root'] = None
     args['leafs'] = []
+    # TODO: simplify when parameter parsing is refactored
+    worker_trials = ExperimentBuilder().fetch_full_config(args)['worker_trials']
     experiment = EVCBuilder().build_from(args)
-    workon(experiment)
+    workon(experiment, worker_trials)

--- a/src/orion/core/io/resolve_config.py
+++ b/src/orion/core/io/resolve_config.py
@@ -55,6 +55,7 @@ log = logging.getLogger(__name__)
 
 # Default settings for command line arguments (option, description)
 DEF_CMD_MAX_TRIALS = (infinity, 'inf/until preempted')
+DEF_CMD_WORKER_TRIALS = (infinity, 'inf/until preempted')
 DEF_CMD_POOL_SIZE = (10, str(10))
 
 DEF_CONFIG_FILES_PATHS = [
@@ -106,6 +107,7 @@ def fetch_default_options():
     # get some defaults
     default_config['name'] = None
     default_config['max_trials'] = DEF_CMD_MAX_TRIALS[0]
+    default_config['worker_trials'] = DEF_CMD_WORKER_TRIALS[0]
     default_config['pool_size'] = DEF_CMD_POOL_SIZE[0]
     default_config['algorithms'] = 'random'
 

--- a/src/orion/core/worker/__init__.py
+++ b/src/orion/core/worker/__init__.py
@@ -10,6 +10,7 @@
 
 """
 import io
+import itertools
 import logging
 import pprint
 
@@ -20,13 +21,18 @@ from orion.core.worker.producer import Producer
 log = logging.getLogger(__name__)
 
 
-def workon(experiment):
+def workon(experiment, worker_trials=None):
     """Try to find solution to the search problem defined in `experiment`."""
     producer = Producer(experiment)
     consumer = Consumer(experiment)
 
     log.debug("#####  Init Experiment  #####")
-    while True:
+    try:
+        iterator = range(int(worker_trials))
+    except (OverflowError, TypeError):
+        # When worker_trials is inf
+        iterator = itertools.count()
+    for _ in iterator:
         log.debug("#### Try to reserve a new trial to evaluate.")
         trial = experiment.reserve_trial(score_handle=producer.algorithm.score)
 

--- a/tests/functional/parsing/test_parsing_hunt.py
+++ b/tests/functional/parsing/test_parsing_hunt.py
@@ -26,7 +26,7 @@ def test_hunt_command_full_parsing(database, monkeypatch):
     parser, subparsers = _create_parser()
     args_list = ["hunt", "-n", "test",
                  "--config", "./orion_config_random.yaml",
-                 "--max-trials", "400", "--pool-size", "4",
+                 "--max-trials", "400", "--pool-size", "4", "--worker-trials", "5",
                  "./black_box.py", "-x~normal(1,1)"]
 
     hunt.add_subparser(subparsers)
@@ -38,3 +38,4 @@ def test_hunt_command_full_parsing(database, monkeypatch):
     assert args['user_args'] == ['./black_box.py', '-x~normal(1,1)']
     assert args['pool_size'] == 4
     assert args['max_trials'] == 400
+    assert args['worker_trials'] == 5


### PR DESCRIPTION
Why:
-----
Sometimes it is desirable to limit number of trials to run on a specific node without changing the total number of trials for the whole experiment. For example, one could run only one trial per node on a cluster with `max_trials` set to some value. This helps to schedule jobs better on a cluster.

How:
-----
`--worker-trials` affects only a specific worker. The worker exits when either `max_trials` for the experiment reached or `worker_trials`.